### PR TITLE
feat(cyw43/tap): macOS utun, UDP NAT, TFTP host-ACK pacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A from-scratch emulator for Raspberry Pi RP2040 and RP2350 microcontrollers, sup
 | Debugging | GDB RSP | Breakpoints, watchpoints, conditional breakpoints, dual-core threads (`-gdb`), architecture-aware registers |
 | Flash | Write-through + FUSE | `-flash <path>` with sync; `-mount <dir>` for live host access (thread-safe) |
 | Storage | SD card + eMMC | SPI-attached file-backed block devices |
-| WiFi | CYW43 (Pico W) | gSPI-over-PIO, TAP bridge with auto IP/NAT (`-wifi`, `-tap`) |
+| WiFi | CYW43 (Pico W) | gSPI-over-PIO, TAP bridge with auto IP/NAT (`-wifi`, `-tap` (Linux TAP / macOS utun)) |
 | Virtual Network | VNet bus | Central Ethernet frame router, TAP/NAT bridge (`-net`), peer mesh (`-net-peer`), W5500 live sockets (`-net-live`) |
 | Multi-Device | Wire + SDD | Wire UART/GPIO/Ethernet between instances, pluggable software-defined devices (`-sdd`) |
 | Performance | ICache + JIT | 64K decoded cache by default, optional hot-block JIT (`-jit`) |

--- a/docs/MACOS-WIFI.md
+++ b/docs/MACOS-WIFI.md
@@ -1,0 +1,18 @@
+# macOS CYW43 host bridge
+
+`-wifi -tap` on macOS uses **utun** (L3) instead of Linux TAP (L2). Bramble adapts Ethernet frames to/from IPv4.
+
+- Guest DHCP: `192.168.4.2/24`, gateway `192.168.4.1`, DNS `8.8.8.8` (emulator-provided)
+- **UDP** (DNS/NTP/TFTP): userspace NAT via host sockets (no pf required)
+- **TCP/ICMP**: optional pf NAT:
+
+```bash
+sudo ./scripts/macos-cyw43-pf-nat.sh enable
+sudo ./scripts/macos-cyw43-pf-nat.sh disable
+```
+
+Example:
+
+```bash
+./bramble firmware.uf2 -wifi -tap utun
+```

--- a/include/corepool.h
+++ b/include/corepool.h
@@ -3,6 +3,7 @@
 
 #include <pthread.h>
 #include <stdint.h>
+#include <unistd.h>
 
 /* ========================================================================
  * Core Pool — Host-Threaded Execution & Multi-Instance Coordination

--- a/include/cyw43.h
+++ b/include/cyw43.h
@@ -15,12 +15,14 @@
  *   Functions: 0=bus, 1=backplane, 2=wlan
  *
  * TAP Bridge (optional):
- *   -tap <ifname> bridges CYW43 WLAN data frames to a Linux TAP interface,
+ *   -tap <ifname> bridges CYW43 WLAN data frames to a host virtual interface,
  *   enabling real internet access for emulated Pico W firmware.
+ *   Linux: TAP + iptables/nft NAT.  macOS: utun + Ethernet↔IPv4 + pf NAT helper.
  *
  * Usage:
- *   ./bramble firmware.uf2 -wifi              # Stub mode (no networking)
- *   ./bramble firmware.uf2 -wifi -tap tap0    # TAP bridge mode
+ *   ./bramble firmware.uf2 -wifi              # Join + fake DHCP only
+ *   ./bramble firmware.uf2 -wifi -tap tap0    # Bridge to host / internet
+ *   # macOS internet: sudo scripts/macos-cyw43-pf-nat.sh enable
  */
 
 #ifndef CYW43_H
@@ -218,6 +220,7 @@ typedef struct {
 typedef struct {
     int enabled;
     int initialized;
+    int feedbead_ok;         /* SPI_READ_TEST_REGISTER seen (bus bring-up) */
 
     /* gSPI state */
     cyw43_spi_state_t spi;
@@ -232,10 +235,12 @@ typedef struct {
     /* Backplane (function 1) */
     uint32_t bp_window;
     uint32_t chipclkcsr;
+    uint32_t sleepcsr;           /* SBSDIO_FUNC1_SLEEPCSR (KSO) */
 
     /* WiFi state */
     int wifi_state;
     char connected_ssid[CYW43_MAX_SSID_LEN + 1];
+    int password_provided;   /* WLC_SET_WSEC_PMK seen (not validated) */
     uint8_t mac_addr[CYW43_MAC_LEN];
     uint32_t ip_addr;
 

--- a/include/tapif.h
+++ b/include/tapif.h
@@ -1,29 +1,32 @@
-/*
- * TAP Interface for CYW43 WiFi Bridge
- *
- * Creates a Linux TAP virtual network interface and bridges
- * Ethernet frames between the emulated CYW43 and the host network.
- *
- * Usage: ./bramble firmware.uf2 -wifi -tap <ifname>
- *
- * Linux only (requires /dev/net/tun).
- */
-
 #ifndef TAPIF_H
 #define TAPIF_H
 
 #include <stdint.h>
 
-/* Open a TAP interface. Returns fd or -1 on error. */
+/*
+ * Host virtual interface for CYW43 WLAN Ethernet frames.
+ *
+ * Linux: TAP (L2).  macOS: utun (L3) with Ethernet↔IPv4 adaptation.
+ * Subnet: guest 192.168.4.2 / host 192.168.4.1 (matches CYW43 DHCP).
+ *
+ * Usage: ./bramble firmware.uf2 -wifi -tap <ifname>
+ * macOS: UDP (DNS/NTP/TFTP) uses userspace NAT; pf optional for TCP.
+ */
+
+/* Open host interface. Returns fd or -1 on error. */
 int tapif_open(const char *name);
 
-/* Close TAP interface */
+/* Close host interface */
 void tapif_close(int fd);
 
-/* Read an Ethernet frame (non-blocking). Returns bytes read, 0 if none, -1 on error. */
+/* Read an Ethernet frame (non-blocking). Returns bytes, 0 if none, -1 on error. */
 int tapif_read(int fd, uint8_t *buf, int maxlen);
 
 /* Write an Ethernet frame. Returns bytes written or -1 on error. */
 int tapif_write(int fd, const uint8_t *buf, int len);
+
+/* Service UDP NAT / TFTP host-ACK without requiring a TAP Ethernet read.
+ * Safe to call often; used when guest radio is asleep but TFTP still runs. */
+void tapif_service(int fd);
 
 #endif /* TAPIF_H */

--- a/scripts/macos-cyw43-pf-nat.sh
+++ b/scripts/macos-cyw43-pf-nat.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Enable/disable pf NAT for Bramble CYW43 utun subnet (192.168.4.0/24) on macOS.
+#
+# Usage:
+#   sudo ./scripts/macos-cyw43-pf-nat.sh enable
+#   sudo ./scripts/macos-cyw43-pf-nat.sh disable
+#   ./scripts/macos-cyw43-pf-nat.sh status
+#
+# Uses a dedicated pf anchor so we do not rewrite the user's global ruleset.
+set -euo pipefail
+
+ANCHOR="bramble_cyw43"
+SUBNET="192.168.4.0/24"
+TMP_DIR="${TMPDIR:-/tmp}"
+ANCHOR_FILE="$TMP_DIR/bramble-cyw43-pf.anchor"
+CONF_FILE="$TMP_DIR/bramble-cyw43-pf.conf"
+
+detect_outgoing() {
+  route -n get default 2>/dev/null | awk '/interface:/{print $2; exit}'
+}
+
+cmd="${1:-status}"
+case "$cmd" in
+  enable)
+    if [[ "$(id -u)" -ne 0 ]]; then
+      echo "Need root: sudo $0 enable" >&2
+      exit 1
+    fi
+    out_if="$(detect_outgoing)"
+    if [[ -z "$out_if" ]]; then
+      echo "No default route interface found" >&2
+      exit 1
+    fi
+    cat >"$ANCHOR_FILE" <<EOF
+# Bramble CYW43 guest subnet → $out_if
+nat on $out_if from $SUBNET to any -> ($out_if)
+pass from $SUBNET to any keep state
+pass from any to $SUBNET keep state
+EOF
+    cat >"$CONF_FILE" <<EOF
+# Minimal loader for Bramble anchor (does not replace system pf.conf)
+anchor "$ANCHOR"
+load anchor "$ANCHOR" from "$ANCHOR_FILE"
+EOF
+    # Enable pf if needed, then load only our anchor into the running ruleset.
+    pfctl -e 2>/dev/null || true
+    if ! pfctl -a "$ANCHOR" -f "$ANCHOR_FILE" 2>/dev/null; then
+      # Some systems require referencing the anchor from main; try flush+load via conf.
+      pfctl -f "$CONF_FILE" 2>/dev/null || {
+        echo "pfctl failed to load anchor '$ANCHOR'." >&2
+        echo "You can also add this to /etc/pf.conf and 'sudo pfctl -f /etc/pf.conf':" >&2
+        echo "  anchor \"$ANCHOR\"" >&2
+        echo "  load anchor \"$ANCHOR\" from \"$ANCHOR_FILE\"" >&2
+        exit 1
+      }
+    fi
+    sysctl -w net.inet.ip.forwarding=1 >/dev/null
+    echo "[bramble-pf] NAT enabled: $SUBNET → $out_if (anchor $ANCHOR)"
+    ;;
+  disable)
+    if [[ "$(id -u)" -ne 0 ]]; then
+      echo "Need root: sudo $0 disable" >&2
+      exit 1
+    fi
+    pfctl -a "$ANCHOR" -F all 2>/dev/null || true
+    echo "[bramble-pf] anchor $ANCHOR flushed"
+    ;;
+  status)
+    echo "default iface: $(detect_outgoing || echo none)"
+    echo "--- pf anchors ---"
+    pfctl -s Anchors 2>/dev/null | grep -F "$ANCHOR" || echo "(no $ANCHOR)"
+    echo "--- $ANCHOR NAT ---"
+    pfctl -a "$ANCHOR" -s nat 2>/dev/null || true
+    ;;
+  *)
+    echo "Usage: $0 enable|disable|status" >&2
+    exit 2
+    ;;
+esac

--- a/src/corepool.c
+++ b/src/corepool.c
@@ -28,6 +28,15 @@
 #include "timer.h"
 #include "usb.h"
 
+/* macOS pthread_cond_timedwait uses CLOCK_REALTIME; no setclock API */
+#if defined(__APPLE__)
+#define COREPOOL_COND_CLOCK_ID CLOCK_REALTIME
+#define COREPOOL_COND_USE_SETCLOCK 0
+#else
+#define COREPOOL_COND_CLOCK_ID CLOCK_MONOTONIC
+#define COREPOOL_COND_USE_SETCLOCK 1
+#endif
+
 /*
  * Each host thread keeps the big lock for a short burst of guest work before
  * yielding. This cuts mutex/scheduler overhead without changing interrupt
@@ -71,7 +80,9 @@ void corepool_init(void) {
 
     pthread_condattr_t attr;
     pthread_condattr_init(&attr);
-    pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
+#if COREPOOL_COND_USE_SETCLOCK
+    pthread_condattr_setclock(&attr, COREPOOL_COND_CLOCK_ID);
+#endif
     pthread_cond_init(&corepool.wfi_cond, &attr);
     pthread_condattr_destroy(&attr);
 
@@ -287,7 +298,7 @@ static void *core_thread_fn(void *arg) {
             if (cores[core_id].is_halted) {
                 /* Halted core: sleep briefly then re-check (may be re-launched) */
                 struct timespec ts;
-                clock_gettime(CLOCK_MONOTONIC, &ts);
+                clock_gettime(COREPOOL_COND_CLOCK_ID, &ts);
                 ts.tv_nsec += 1000000;  /* 1ms */
                 if (ts.tv_nsec >= 1000000000) {
                     ts.tv_sec++;
@@ -317,7 +328,7 @@ static void *core_thread_fn(void *arg) {
                 struct timespec end;
 
                 clock_gettime(CLOCK_MONOTONIC, &start);
-                ts = start;
+                clock_gettime(COREPOOL_COND_CLOCK_ID, &ts);
                 ts.tv_nsec += 1000000;  /* 1ms */
                 if (ts.tv_nsec >= 1000000000) {
                     ts.tv_sec++;
@@ -336,11 +347,10 @@ static void *core_thread_fn(void *arg) {
                     systick_tick_for_core(core_id, (uint32_t)elapsed_cycles);
                 }
 
-                /* If every active core is sleeping/halted, use host elapsed time
-                 * as a fallback so timer-driven wakeups still happen. */
-                if (core_id == CORE0 &&
-                    (num_active_cores == 1 || cores[CORE1].is_wfi || cores[CORE1].is_halted) &&
-                    elapsed_us > 0) {
+                /* Any core in WFI/WFE: advance shared TIMER by host elapsed so
+                 * sleep_until/alarms work while the peer core stays busy (e.g.
+                 * cyw43_arch_init on core0 + BusLoop on core1). */
+                if (elapsed_us > 0) {
                     timer_tick(elapsed_us);
                     rtc_tick(elapsed_us);
                 }

--- a/src/cyw43.c
+++ b/src/cyw43.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <string.h>
+#include <errno.h>
 #include <arpa/inet.h>
 #include "cyw43.h"
 #include "tapif.h"
@@ -90,6 +91,12 @@ static void rx_queue_pop(void) {
  * SDPCM Frame Construction Helpers
  * ======================================================================== */
 
+/* Firmware stalls TX while last_bus_data_credit == next TX sequence
+ * (cyw43_ll sdpcm_send_common). Credits advance only via RX SDPCM headers.
+ * After DHCP, DNS/NTP TX with no RX exhausts the window → STALL timeout.
+ * Offer a window of 8 ahead of the last firmware TX sequence. */
+#define CYW43_SDPCM_CREDIT_WINDOW 8
+
 static void sdpcm_fill_header(uint8_t *buf, int total_size, uint8_t channel, uint8_t hdr_len) {
     sdpcm_header_t *h = (sdpcm_header_t *)buf;
     memset(h, 0, sizeof(*h));
@@ -98,7 +105,19 @@ static void sdpcm_fill_header(uint8_t *buf, int total_size, uint8_t channel, uin
     h->sequence = cyw43.tx_seq++;
     h->channel_and_flags = channel;
     h->header_length = hdr_len;
-    h->bus_data_credit = (uint8_t)(cyw43.last_fw_seq + 4);
+    h->bus_data_credit = (uint8_t)(cyw43.last_fw_seq + CYW43_SDPCM_CREDIT_WINDOW);
+}
+
+/* SDPCM header-only frame: firmware updates credits then ignores as data. */
+static void cyw43_queue_credit_refresh(void) {
+    uint8_t frame[12];
+    sdpcm_fill_header(frame, 12, SDPCM_CONTROL_CHANNEL, 12);
+    if (rx_queue_push(frame, 12) < 0) {
+        static int once;
+        if (!once++) {
+            fprintf(stderr, "[CYW43] credit refresh dropped (RX queue full)\n");
+        }
+    }
 }
 
 /* Build an IOCTL response and queue it */
@@ -300,6 +319,9 @@ static void cyw43_handle_ioctl(const uint8_t *buf, int len) {
     case WLC_GET_VAR: {
         /* payload is null-terminated iovar name */
         const char *varname = (const char *)payload;
+        fprintf(stderr, "[CYW43] GET_VAR '%s' (payload_len=%d)\n",
+                varname[0] ? varname : "(empty)", payload_len);
+        fflush(stderr);
 
         if (strcmp(varname, "cur_etheraddr") == 0) {
             cyw43_queue_ioctl_response(cmd, ioctl_id, cyw43.mac_addr, 6, 0);
@@ -309,6 +331,14 @@ static void cyw43_handle_ioctl(const uint8_t *buf, int len) {
             const char *ver = "wl0: Bramble CYW43 Emulator\n";
             cyw43_queue_ioctl_response(cmd, ioctl_id,
                                         (const uint8_t *)ver, (int)strlen(ver) + 1, 0);
+            return;
+        }
+        /* CLM blob load status: 0 = complete/OK. Returning zeros left firmware
+         * spinning / HardFaulting BusLoop during cyw43_arch_init. */
+        if (strcmp(varname, "clmload_status") == 0) {
+            int32_t status = 0;
+            cyw43_queue_ioctl_response(cmd, ioctl_id,
+                                        (const uint8_t *)&status, (int)sizeof(status), 0);
             return;
         }
         /* Default: return zeros */
@@ -322,22 +352,44 @@ static void cyw43_handle_ioctl(const uint8_t *buf, int len) {
 
     case WLC_SET_SSID: {
         /* Payload: 4 bytes SSID length + SSID string (32 bytes) */
+        uint32_t ssid_len = 0;
         if (payload_len >= 36) {
-            uint32_t ssid_len = payload[0] | (payload[1] << 8) |
-                                (payload[2] << 16) | (payload[3] << 24);
+            ssid_len = payload[0] | (payload[1] << 8) |
+                       (payload[2] << 16) | (payload[3] << 24);
             if (ssid_len > CYW43_MAX_SSID_LEN) ssid_len = CYW43_MAX_SSID_LEN;
             memcpy(cyw43.connected_ssid, payload + 4, ssid_len);
             cyw43.connected_ssid[ssid_len] = '\0';
-
-            if (cpu.debug_enabled)
-                fprintf(stderr, "[CYW43] JOIN SSID: '%s'\n", cyw43.connected_ssid);
+        } else {
+            cyw43.connected_ssid[0] = '\0';
         }
 
-        /* Respond success */
-        cyw43_queue_ioctl_response(cmd, ioctl_id, NULL, 0, 0);
+        fprintf(stderr, "[CYW43] JOIN SSID='%s' (len=%u)%s\n",
+                cyw43.connected_ssid, ssid_len,
+                cyw43.password_provided ? " [passphrase set]" : " [no passphrase yet]");
 
-        /* Queue connection events */
+        if (ssid_len == 0) {
+            fprintf(stderr, "[CYW43] JOIN refused: empty SSID (no link-up events)\n");
+            cyw43.wifi_state = CYW43_WIFI_OFF;
+            cyw43_queue_ioctl_response(cmd, ioctl_id, NULL, 0, 0);
+            return;
+        }
+
+        /* Respond success and simulate association */
+        cyw43_queue_ioctl_response(cmd, ioctl_id, NULL, 0, 0);
         cyw43_queue_connect_events();
+        return;
+    }
+
+    case WLC_SET_WSEC_PMK: {
+        /* Passphrase / PMK for WPA — accept any; host never joins a real AP. */
+        cyw43.password_provided = 1;
+        uint32_t key_len = 0;
+        if (payload_len >= 2) {
+            key_len = payload[0] | ((uint32_t)payload[1] << 8);
+        }
+        fprintf(stderr, "[CYW43] WPA passphrase provided (reported_len=%u, payload=%d)\n",
+                key_len, payload_len);
+        cyw43_queue_ioctl_response(cmd, ioctl_id, NULL, 0, 0);
         return;
     }
 
@@ -382,9 +434,13 @@ static void cyw43_handle_ioctl(const uint8_t *buf, int len) {
  * Fake DHCP Server (assigns 192.168.4.2 to firmware, no real network needed)
  * ======================================================================== */
 
-/* Fixed IP addressing for the virtual WiFi network */
+/* Fixed IP addressing for the virtual WiFi network.
+ * DNS must be a public resolver — not 192.168.4.1. The host utun address is
+ * only a gateway; nothing listens on :53 there, so guest DNS to the gateway
+ * never gets a reply. With pf/iptables NAT, 8.8.8.8 reaches the internet. */
 static const uint8_t dhcp_client_ip[4]  = {192, 168,   4, 2};
 static const uint8_t dhcp_server_ip[4]  = {192, 168,   4, 1};
+static const uint8_t dhcp_dns_ip[4]     = {8, 8, 8, 8};
 static const uint8_t dhcp_subnet[4]     = {255, 255, 255, 0};
 static const uint8_t dhcp_lease_time[4] = {0, 0, 14, 16};  /* 3600 s */
 
@@ -466,8 +522,12 @@ static void cyw43_send_dhcp_reply(const uint8_t *eth_req, int eth_len, uint8_t r
     frame[off++] =  3; frame[off++] = 4;
     memcpy(frame + off, dhcp_server_ip, 4);     off += 4;  /* router */
     frame[off++] =  6; frame[off++] = 4;
-    memcpy(frame + off, dhcp_server_ip, 4);     off += 4;  /* DNS */
+    memcpy(frame + off, dhcp_dns_ip, 4);        off += 4;  /* DNS (public) */
     frame[off++] = 255;                                    /* end */
+    /* lwIP dhcp_parse_reply under Thumb emu issues a 4-byte pbuf_copy_partial
+     * at the END option offset (IT/cmp edge). Trailing pad makes that read
+     * succeed so parse can still see END and return ERR_OK. */
+    frame[off++] = 0; frame[off++] = 0; frame[off++] = 0; frame[off++] = 0;
 
     /* Fill in lengths */
     int ip_total  = off - ip_off;
@@ -490,11 +550,16 @@ static void cyw43_send_dhcp_reply(const uint8_t *eth_req, int eth_len, uint8_t r
 
     cyw43_queue_rx_data(frame, off);
 
-    if (cpu.debug_enabled)
-        fprintf(stderr, "[CYW43] DHCP %s → offer %d.%d.%d.%d\n",
-                reply_type == 2 ? "DISCOVER" : "REQUEST",
-                dhcp_client_ip[0], dhcp_client_ip[1],
-                dhcp_client_ip[2], dhcp_client_ip[3]);
+    fprintf(stderr,
+            "[CYW43] DHCP %s → %d.%d.%d.%d/24 gw %d.%d.%d.%d dns %d.%d.%d.%d\n",
+            reply_type == 2 ? "OFFER" : "ACK",
+            dhcp_client_ip[0], dhcp_client_ip[1],
+            dhcp_client_ip[2], dhcp_client_ip[3],
+            dhcp_server_ip[0], dhcp_server_ip[1],
+            dhcp_server_ip[2], dhcp_server_ip[3],
+            dhcp_dns_ip[0], dhcp_dns_ip[1],
+            dhcp_dns_ip[2], dhcp_dns_ip[3]);
+    fflush(stderr);
 }
 
 /* Returns 1 if this was a DHCP packet that we handled, 0 otherwise. */
@@ -587,13 +652,58 @@ static void cyw43_wlan_tx_complete(void) {
             int eth_len = len - eth_offset;
             if (eth_len > 0) {
                 const uint8_t *eth = cyw43.wlan_tx_buf + eth_offset;
+                {
+                    static int tx_logged;
+                    if (tx_logged < 8) {
+                        tx_logged++;
+                        fprintf(stderr,
+                                "[CYW43] WLAN DATA TX %d bytes ethertype=%02x%02x\n",
+                                eth_len,
+                                eth_len >= 14 ? eth[12] : 0,
+                                eth_len >= 14 ? eth[13] : 0);
+                        fflush(stderr);
+                    }
+                }
                 /* Always try fake DHCP first (no real network needed) */
                 if (!cyw43_handle_dhcp(eth, eth_len)) {
-                    /* Not DHCP: forward to TAP interface if available */
+                    /* Not DHCP: forward to TAP/utun if available */
                     if (cyw43.tap_fd >= 0) {
+                        {
+                            static int tap_tx_logged;
+                            if (tap_tx_logged < 12 && eth_len >= 34 &&
+                                eth[12] == 0x08 && eth[13] == 0x00) {
+                                const uint8_t *ip = eth + 14;
+                                int ihl = (ip[0] & 0x0F) * 4;
+                                tap_tx_logged++;
+                                if (ip[9] == 17 && eth_len >= 14 + ihl + 8) {
+                                    const uint8_t *udp = ip + ihl;
+                                    uint16_t dport = ((uint16_t)udp[2] << 8) | udp[3];
+                                    fprintf(stderr,
+                                            "[CYW43] TAP TX UDP %d.%d.%d.%d:%u (%d eth bytes)\n",
+                                            ip[16], ip[17], ip[18], ip[19],
+                                            (unsigned)dport, eth_len);
+                                } else {
+                                    fprintf(stderr,
+                                            "[CYW43] TAP TX IP proto=%u → %d.%d.%d.%d (%d eth bytes)\n",
+                                            ip[9], ip[16], ip[17], ip[18], ip[19],
+                                            eth_len);
+                                }
+                                fflush(stderr);
+                            }
+                        }
                         tapif_write(cyw43.tap_fd, eth, eth_len);
                         if (cpu.debug_enabled)
                             fprintf(stderr, "[CYW43] TAP TX: %d bytes\n", eth_len);
+                    } else {
+                        static int no_tap_warned;
+                        if (no_tap_warned < 3) {
+                            no_tap_warned++;
+                            fprintf(stderr,
+                                    "[CYW43] drop WLAN TX (%d bytes) — no host bridge "
+                                    "(-tap / UDP NAT)\n",
+                                    eth_len);
+                            fflush(stderr);
+                        }
                     }
                 }
             }
@@ -608,6 +718,8 @@ static void cyw43_wlan_tx_complete(void) {
     }
 
     cyw43.wlan_tx_offset = 0;
+    /* Keep SDPCM TX credits ahead of firmware seq even when TAP is quiet. */
+    cyw43_queue_credit_refresh();
 }
 
 /* Forward declarations for PIO gSPI state (defined in PIO section below) */
@@ -649,6 +761,7 @@ void cyw43_reset(void) {
     snprintf(cyw43.country, sizeof(cyw43.country), "XX");
     cyw43.wifi_state = CYW43_WIFI_OFF;
     cyw43.chipclkcsr = CYW43_HT_AVAIL | CYW43_ALP_AVAIL;
+    cyw43.sleepcsr = 0x03; /* KSO_SET | DEV_ON — awake after reset */
     cyw43.pio_num = -1;
     cyw43.pio_sm = -1;
     pio_init_swap_remaining = 2;  /* First 2 commands use SWAP32 encoding */
@@ -687,20 +800,55 @@ void cyw43_tap_close(void) {
 
 void cyw43_tap_poll(void) {
     if (cyw43.tap_fd < 0) return;
+
+    /*
+     * Always service UDP NAT (DNS/NTP/TFTP host-ACK) even if the guest has
+     * put the radio to sleep — otherwise long TFTP stalls when kso_set(0)
+     * runs and guest stops calling into the WLAN RX path.
+     */
+    tapif_service(cyw43.tap_fd);
+
     if (cyw43.wifi_state != CYW43_WIFI_CONNECTED) return;
 
     /* Read Ethernet frames from TAP and queue for firmware */
     uint8_t eth_buf[1518];  /* Max Ethernet frame (tapif_read clamps to this) */
     int n = tapif_read(cyw43.tap_fd, eth_buf, (int)sizeof(eth_buf));
     if (n > 0) {
+        {
+            static int tap_rx_logged;
+            if (tap_rx_logged < 8 && n >= 34 &&
+                eth_buf[12] == 0x08 && eth_buf[13] == 0x00) {
+                const uint8_t *ip = eth_buf + 14;
+                int ihl = (ip[0] & 0x0F) * 4;
+                tap_rx_logged++;
+                if (ip[9] == 17 && n >= 14 + ihl + 8) {
+                    const uint8_t *udp = ip + ihl;
+                    uint16_t sport = ((uint16_t)udp[0] << 8) | udp[1];
+                    fprintf(stderr,
+                            "[CYW43] TAP RX UDP %d.%d.%d.%d:%u → guest (%d eth bytes)\n",
+                            ip[12], ip[13], ip[14], ip[15],
+                            (unsigned)sport, n);
+                } else {
+                    fprintf(stderr,
+                            "[CYW43] TAP RX IP proto=%u from %d.%d.%d.%d (%d eth bytes)\n",
+                            ip[9], ip[12], ip[13], ip[14], ip[15], n);
+                }
+                fflush(stderr);
+            }
+        }
         cyw43_queue_rx_data(eth_buf, n);
         if (cpu.debug_enabled)
             fprintf(stderr, "[CYW43] TAP RX: %d bytes queued\n", n);
     } else if (n < 0) {
-        /* Persistent error — close TAP to avoid spin-polling a dead fd */
-        fprintf(stderr, "[CYW43] TAP read error, closing interface\n");
-        tapif_close(cyw43.tap_fd);
-        cyw43.tap_fd = -1;
+        /* Do not tear down the bridge: on macOS UDP NAT/ARP still need tap_fd.
+         * Closing here killed DNS after a transient utun read error. */
+        static int tap_err_logged;
+        if (tap_err_logged < 3) {
+            tap_err_logged++;
+            fprintf(stderr, "[CYW43] TAP read error (%s) — keeping bridge\n",
+                    strerror(errno));
+            fflush(stderr);
+        }
     }
 }
 
@@ -735,6 +883,7 @@ static uint32_t cyw43_bus_read(uint32_t addr) {
         return val;
     }
     case 0x14: /* SPI_READ_TEST_REGISTER = FEEDBEAD */
+        cyw43.feedbead_ok = 1;
         return 0xFEEDBEAD;
     case 0x18:
         return cyw43.bus_test_reg;
@@ -788,8 +937,8 @@ static uint32_t cyw43_backplane_read(uint32_t addr) {
 
     /* SDIO func1 direct registers (full 17-bit address, no windowing) */
     if (addr == 0x1001F) {
-        /* SBSDIO_FUNC1_SLEEPCSR (KSO): always return KSO_SET | DEVICE_ON = 0x03 */
-        return 0x03;
+        /* SBSDIO_FUNC1_SLEEPCSR — see write path (KSO clear + KSO|DEVON wake). */
+        return cyw43.sleepcsr & 0xFFu;
     }
 
     /* Windowed backplane access: reconstruct full address from window + offset */
@@ -829,6 +978,25 @@ static void cyw43_backplane_write(uint32_t addr, uint32_t val) {
     /* CHIPCLKCSR write (SDIO func1 direct register) */
     if (addr == CYW43_BP_CHIPCLKCSR) {
         cyw43.chipclkcsr = val | CYW43_HT_AVAIL | CYW43_ALP_AVAIL;
+        return;
+    }
+    if (addr == 0x1001F) {
+        /* cyw43_kso_set(1) polls until (SLEEPCSR & 0x03) == 0x03 (KSO|DEVON).
+         * Hardware sets DEVON after KSO; storing write-as-is (0x01) made wake
+         * fail → 64× delay_ms busy-loops that starve TFTP host-ACK. */
+        static int kso_logged;
+        uint8_t v = (uint8_t)(val & 0xFFu);
+        if (v & 0x01u)
+            v |= 0x02u;
+        else
+            v &= (uint8_t)~0x03u;
+        cyw43.sleepcsr = v;
+        if (kso_logged < 8) {
+            kso_logged++;
+            fprintf(stderr, "[CYW43] SLEEPCSR write → 0x%02X\n",
+                    (unsigned)cyw43.sleepcsr);
+            fflush(stderr);
+        }
         return;
     }
 
@@ -1010,6 +1178,11 @@ void cyw43_pio_tx_write(uint32_t val) {
         return;
     }
 
+    /* Belt-and-suspenders: direct pio_sm_put bit-counts are always small
+     * (< 8 * max_transfer). Real gSPI command words after DMA bswap are not. */
+    if (pio_cyw43_phase == PIO_CYW43_IDLE && val < 0x10000u)
+        return;
+
     switch (pio_cyw43_phase) {
     case PIO_CYW43_IDLE: {
         /* Determine encoding: first 2 commands at boot use SWAP32 (rev16+bswap),
@@ -1053,6 +1226,8 @@ void cyw43_pio_tx_write(uint32_t val) {
             switch (pio_cmd_function) {
             case CYW43_FUNC_BUS: {
                 uint32_t resp = cyw43_bus_read(pio_cmd_address);
+                if (pio_cmd_address == 0x14)
+                    fprintf(stderr, "[CYW43] SPI_READ_TEST_REGISTER → 0x%08X\n", resp);
                 pio_resp_buf[0] = cyw43_encode_resp(resp, pio_cmd_is_swap);
                 pio_resp_count = total_words;
                 break;
@@ -1089,9 +1264,18 @@ void cyw43_pio_tx_write(uint32_t val) {
                     pio_resp_count = total_words;
                     rx_queue_pop();
 
-                    if (cpu.debug_enabled)
-                        fprintf(stderr, "[CYW43] WLAN RX: delivering %d byte frame (ch=%d seq=%d)\n",
-                                copy_len, f->data[4] & 0x0F, f->data[3]);
+                    {
+                        /* Always log data-channel / large frames (DHCP OFFER ~300B+). */
+                        uint8_t ch = f->data[5] & 0x0Fu;
+                        uint8_t seq = f->data[4];
+                        if (copy_len >= 64 || ch == SDPCM_DATA_CHANNEL) {
+                            fprintf(stderr,
+                                    "[CYW43] WLAN RX: delivering %d byte frame "
+                                    "(ch=%u seq=%u)\n",
+                                    copy_len, (unsigned)ch, (unsigned)seq);
+                            fflush(stderr);
+                        }
+                    }
                 } else {
                     /* No data - return empty SDPCM (size=0) */
                     pio_resp_count = total_words;
@@ -1131,8 +1315,9 @@ void cyw43_pio_tx_write(uint32_t val) {
     }
 
     case PIO_CYW43_READ:
-        pio_cyw43_phase = PIO_CYW43_IDLE;
-        cyw43_pio_tx_write(val);
+        /* Full-duplex / countdown dummy TX during an outstanding read.
+         * Do not abort the response — firmware may still clock TXF while
+         * DMA drains RXF (or after Y is loaded). */
         break;
     }
 }

--- a/src/tapif.c
+++ b/src/tapif.c
@@ -1,13 +1,14 @@
 /*
- * TAP Interface for CYW43 WiFi Bridge
+ * Host network interface for CYW43 WiFi bridge.
  *
- * Creates a Linux TAP virtual network interface and configures the host
- * side for bridging Ethernet frames between the emulated CYW43 and the
- * host network.
+ * Linux: TAP (/dev/net/tun) carrying raw Ethernet frames + iptables/nft NAT.
+ * macOS: utun (L3) with Ethernet↔IPv4 adaptation + optional pf NAT helper.
  *
- * On open: creates TAP, assigns 192.168.4.1/24, brings interface UP,
- * enables IP forwarding, and sets up NAT masquerade on the default route.
- * On close: removes the NAT rule and restores forwarding state.
+ * Virtual subnet (matches CYW43 fake DHCP):
+ *   Guest  192.168.4.2
+ *   Host   192.168.4.1
+ *
+ * Usage: ./bramble firmware.uf2 -wifi -tap <ifname>
  */
 
 #include <stdio.h>
@@ -18,30 +19,28 @@
 #include <errno.h>
 #include "tapif.h"
 
+#define TAP_HOST_IP     "192.168.4.1"
+#define TAP_PEER_IP     "192.168.4.2"
+#define TAP_SUBNET      "192.168.4.0/24"
+#define TAP_NETMASK     "255.255.255.0"
+
+static int run_cmd(const char *cmd) {
+    int rc = system(cmd);
+    return WIFEXITED(rc) ? WEXITSTATUS(rc) : -1;
+}
+
 #ifdef __linux__
 #include <sys/ioctl.h>
 #include <net/if.h>
 #include <linux/if_tun.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <sys/wait.h>
 
-/* The virtual subnet used by the CYW43 DHCP server */
-#define TAP_HOST_IP     "192.168.4.1"
-#define TAP_SUBNET      "192.168.4.0/24"
-#define TAP_NETMASK     "255.255.255.0"
-
-/* State for cleanup */
 static char tap_ifname[IFNAMSIZ];
 static int  tap_forwarding_was_enabled = 0;
 static char tap_outgoing_iface[IFNAMSIZ];
 
-/* Run a shell command, return 0 on success */
-static int run_cmd(const char *cmd) {
-    int rc = system(cmd);
-    return WIFEXITED(rc) ? WEXITSTATUS(rc) : -1;
-}
-
-/* Detect the default outgoing interface for NAT masquerade */
 static int detect_outgoing_iface(char *out, size_t out_sz) {
     FILE *f = popen("ip route show default 2>/dev/null | awk '/default/{print $5; exit}'", "r");
     if (!f) return -1;
@@ -50,13 +49,11 @@ static int detect_outgoing_iface(char *out, size_t out_sz) {
         return -1;
     }
     pclose(f);
-    /* Strip trailing newline */
     size_t len = strlen(out);
     if (len > 0 && out[len - 1] == '\n') out[len - 1] = '\0';
     return (out[0] != '\0') ? 0 : -1;
 }
 
-/* Check current IP forwarding state */
 static int get_ip_forwarding(void) {
     FILE *f = fopen("/proc/sys/net/ipv4/ip_forward", "r");
     if (!f) return 0;
@@ -66,7 +63,6 @@ static int get_ip_forwarding(void) {
     return val;
 }
 
-/* Set IP forwarding state */
 static void set_ip_forwarding(int enable) {
     FILE *f = fopen("/proc/sys/net/ipv4/ip_forward", "w");
     if (f) {
@@ -75,7 +71,6 @@ static void set_ip_forwarding(int enable) {
     }
 }
 
-/* Copy interface name safely (always null-terminated, no truncation warning) */
 static void copy_ifname(char *dst, const char *src) {
     memset(dst, 0, IFNAMSIZ);
     size_t len = strlen(src);
@@ -83,13 +78,11 @@ static void copy_ifname(char *dst, const char *src) {
     memcpy(dst, src, len);
 }
 
-/* Assign IP address and bring interface UP using ioctl (no shell commands) */
 static int configure_interface(const char *ifname) {
     struct ifreq ifr;
     int sock = socket(AF_INET, SOCK_DGRAM, 0);
     if (sock < 0) return -1;
 
-    /* Set IP address */
     memset(&ifr, 0, sizeof(ifr));
     copy_ifname(ifr.ifr_name, ifname);
     struct sockaddr_in *addr = (struct sockaddr_in *)&ifr.ifr_addr;
@@ -101,7 +94,6 @@ static int configure_interface(const char *ifname) {
         return -1;
     }
 
-    /* Set netmask */
     inet_pton(AF_INET, TAP_NETMASK, &addr->sin_addr);
     if (ioctl(sock, SIOCSIFNETMASK, &ifr) < 0) {
         fprintf(stderr, "[TAP] Failed to set netmask: %s\n", strerror(errno));
@@ -109,7 +101,6 @@ static int configure_interface(const char *ifname) {
         return -1;
     }
 
-    /* Bring interface UP */
     memset(&ifr, 0, sizeof(ifr));
     copy_ifname(ifr.ifr_name, ifname);
     if (ioctl(sock, SIOCGIFFLAGS, &ifr) < 0) {
@@ -127,29 +118,24 @@ static int configure_interface(const char *ifname) {
     return 0;
 }
 
-/* Set up NAT masquerade for internet access */
 static int setup_nat(void) {
-    /* Detect outgoing interface */
     if (detect_outgoing_iface(tap_outgoing_iface, sizeof(tap_outgoing_iface)) < 0) {
         fprintf(stderr, "[TAP] No default route found — NAT not configured\n");
         fprintf(stderr, "[TAP] Local subnet 192.168.4.0/24 will still work\n");
-        return 0;  /* Not fatal — local communication still works */
+        return 0;
     }
 
-    /* Save and enable IP forwarding */
     tap_forwarding_was_enabled = get_ip_forwarding();
     if (!tap_forwarding_was_enabled) {
         set_ip_forwarding(1);
         fprintf(stderr, "[TAP] Enabled IP forwarding\n");
     }
 
-    /* Add iptables masquerade rule */
     char cmd[256];
     snprintf(cmd, sizeof(cmd),
              "iptables -t nat -A POSTROUTING -s %s -o %s -j MASQUERADE 2>/dev/null",
              TAP_SUBNET, tap_outgoing_iface);
     if (run_cmd(cmd) != 0) {
-        /* Try nftables if iptables not available */
         snprintf(cmd, sizeof(cmd),
                  "nft add rule nat postrouting oifname \"%s\" ip saddr %s masquerade 2>/dev/null",
                  tap_outgoing_iface, TAP_SUBNET);
@@ -163,7 +149,6 @@ static int setup_nat(void) {
     return 0;
 }
 
-/* Remove NAT rule on cleanup */
 static void teardown_nat(void) {
     if (tap_outgoing_iface[0] == '\0') return;
 
@@ -173,7 +158,6 @@ static void teardown_nat(void) {
              TAP_SUBNET, tap_outgoing_iface);
     run_cmd(cmd);
 
-    /* Restore IP forwarding to previous state */
     if (!tap_forwarding_was_enabled) {
         set_ip_forwarding(0);
     }
@@ -198,17 +182,13 @@ int tapif_open(const char *name) {
         return -1;
     }
 
-    /* Set non-blocking */
     int flags = fcntl(fd, F_GETFL, 0);
     if (flags != -1)
         fcntl(fd, F_SETFL, flags | O_NONBLOCK);
 
-    /* Save interface name for cleanup */
     copy_ifname(tap_ifname, ifr.ifr_name);
-
     fprintf(stderr, "[TAP] Interface '%s' created (fd=%d)\n", ifr.ifr_name, fd);
 
-    /* Configure host side: IP, bring UP, NAT */
     if (configure_interface(ifr.ifr_name) == 0) {
         fprintf(stderr, "[TAP] Configured %s as %s/%s\n", ifr.ifr_name, TAP_HOST_IP, TAP_NETMASK);
     } else {
@@ -218,33 +198,19 @@ int tapif_open(const char *name) {
     }
 
     setup_nat();
-
     return fd;
 }
 
-#else /* !__linux__ */
-
-int tapif_open(const char *name) {
-    (void)name;
-    fprintf(stderr, "[TAP] TAP interface only supported on Linux\n");
-    return -1;
-}
-
-#endif /* __linux__ */
-
 void tapif_close(int fd) {
     if (fd >= 0) {
-#ifdef __linux__
         teardown_nat();
         fprintf(stderr, "[TAP] Closed interface '%s'\n", tap_ifname);
-#endif
         close(fd);
     }
 }
 
 int tapif_read(int fd, uint8_t *buf, int maxlen) {
     if (fd < 0) return -1;
-    /* Clamp to Ethernet max frame size (prevent oversized frames) */
     if (maxlen > 1518) maxlen = 1518;
     ssize_t n = read(fd, buf, (size_t)maxlen);
     if (n < 0) {
@@ -269,3 +235,950 @@ int tapif_write(int fd, const uint8_t *buf, int len) {
     }
     return total;
 }
+
+void tapif_service(int fd) {
+    (void)fd;
+}
+
+void tapif_tftp_transfer_done(void) {
+}
+
+#elif defined(__APPLE__)
+
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/sys_domain.h>
+#include <sys/kern_control.h>
+#include <sys/wait.h>
+#include <net/if.h>
+#include <net/if_utun.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <stdint.h>
+#include <time.h>
+
+/* CYW43 guest default MAC / fake BSSID used as gateway L2 address */
+static const uint8_t k_guest_mac[6] = {0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE};
+static const uint8_t k_gw_mac[6]    = {0x02, 0xCA, 0xFE, 0xBA, 0xBE, 0x01};
+static const uint8_t k_host_ip[4]   = {192, 168, 4, 1};
+
+static char utun_ifname[IFNAMSIZ];
+static int darwin_active;
+static int darwin_utun_rx_ok; /* 0 = skip utun read; UDP NAT still active */
+
+/* RX ring: ARP replies + userspace UDP NAT replies (and optional utun). */
+#define DARWIN_RXQ 16
+static uint8_t darwin_rxq[DARWIN_RXQ][1518];
+static int darwin_rxq_len[DARWIN_RXQ];
+static int darwin_rxq_head, darwin_rxq_tail, darwin_rxq_count;
+
+/* Userspace UDP NAT — pf/utun does not reliably forward guest→internet on macOS. */
+#define DARWIN_UDP_FLOWS 32
+typedef struct {
+    int fd;
+    uint32_t guest_ip;    /* network order */
+    uint16_t guest_port;  /* host order */
+    uint32_t remote_ip;   /* network order */
+    uint16_t remote_port; /* host order */
+    time_t last_used;
+} darwin_udp_flow_t;
+static darwin_udp_flow_t darwin_udp_flows[DARWIN_UDP_FLOWS];
+
+/*
+ * TFTP ACK proxy: guest Thumb emu is too slow to ACK before tftpd times out
+ * (even one DATA→ACK round-trip can exceed the server timeout → Unknown TID).
+ * Host ACKs the server immediately, buffers blocks, and paces delivery to the
+ * guest one DATA/OACK at a time (guest ACK advances the queue; not forwarded).
+ */
+#define TFTP_PROXY_QMAX 256 /* buffered blocks awaiting guest */
+#define TFTP_PROXY_WINDOW 32 /* max host-ACKed ahead of guest (keep tftpd alive) */
+typedef struct {
+    uint32_t remote_ip;   /* network order */
+    uint16_t remote_port; /* host order (server TID) */
+    uint16_t len;
+    uint8_t payload[516];
+} tftp_proxy_pkt_t;
+
+static tftp_proxy_pkt_t tftp_proxy_q[TFTP_PROXY_QMAX];
+static int tftp_proxy_q_head;
+static int tftp_proxy_q_count;
+static int tftp_proxy_active;
+static int tftp_proxy_fd = -1;
+static int tftp_proxy_guest_inflight; /* 1 = guest has unacked DATA/OACK */
+static uint16_t tftp_proxy_last_guest_ack;
+static uint32_t tftp_proxy_guest_ip;
+static uint16_t tftp_proxy_guest_port;
+static uint32_t tftp_proxy_remote_ip;
+static unsigned tftp_proxy_host_acks;
+static unsigned tftp_proxy_guest_acks;
+static uint16_t tftp_proxy_last_enqueued; /* last DATA/OACK block buffered */
+static int tftp_proxy_have_enqueued;
+static uint16_t tftp_proxy_last_acked; /* last block host-ACKed (keepalive) */
+static uint16_t tftp_proxy_server_tid; /* server ephemeral port */
+static struct timespec tftp_proxy_last_rx;
+static int tftp_proxy_last_rx_armed;
+static int tftp_proxy_transfer_done;
+static void tftp_proxy_reset(void) {
+    tftp_proxy_q_head = 0;
+    tftp_proxy_q_count = 0;
+    tftp_proxy_active = 0;
+    tftp_proxy_fd = -1;
+    tftp_proxy_guest_inflight = 0;
+    tftp_proxy_last_guest_ack = 0;
+    tftp_proxy_guest_ip = 0;
+    tftp_proxy_guest_port = 0;
+    tftp_proxy_remote_ip = 0;
+    tftp_proxy_host_acks = 0;
+    tftp_proxy_guest_acks = 0;
+    tftp_proxy_last_enqueued = 0;
+    tftp_proxy_have_enqueued = 0;
+    tftp_proxy_last_acked = 0;
+    tftp_proxy_server_tid = 0;
+    tftp_proxy_last_rx_armed = 0;
+    tftp_proxy_transfer_done = 0;
+}
+
+/* True if blk is a retransmit of last (handles uint16 wrap; 0 after 65535
+ * is the *next* block, not a retransmit of 65535). */
+static int tftp_proxy_is_retransmit(uint16_t blk) {
+    uint16_t behind;
+    if (!tftp_proxy_have_enqueued)
+        return 0;
+    if (blk == tftp_proxy_last_enqueued)
+        return 1;
+    behind = (uint16_t)(tftp_proxy_last_enqueued - blk);
+    return behind >= 1u && behind <= 32u;
+}
+
+static void darwin_queue_udp_reply(uint32_t guest_ip, uint16_t guest_port,
+                                   uint32_t remote_ip, uint16_t remote_port,
+                                   const uint8_t *payload, int payload_len);
+
+static void tftp_proxy_host_ack(int fd, uint32_t remote_ip, uint16_t remote_port,
+                                uint16_t block) {
+    uint8_t ack[4];
+    struct sockaddr_in dest;
+    ack[0] = 0;
+    ack[1] = 4; /* ACK */
+    ack[2] = (uint8_t)(block >> 8);
+    ack[3] = (uint8_t)(block & 0xFF);
+    memset(&dest, 0, sizeof(dest));
+    dest.sin_family = AF_INET;
+    dest.sin_port = htons(remote_port);
+    dest.sin_addr.s_addr = remote_ip;
+    if (sendto(fd, ack, 4, 0, (struct sockaddr *)&dest, sizeof(dest)) < 0) {
+        fprintf(stderr, "[TAP] TFTP host-ACK block %u failed: %s\n",
+                (unsigned)block, strerror(errno));
+    } else {
+        tftp_proxy_host_acks++;
+        tftp_proxy_last_acked = block;
+        if (tftp_proxy_host_acks <= 8 || (tftp_proxy_host_acks % 64) == 0) {
+            fprintf(stderr, "[TAP] TFTP host-ACK block %u → :%u (#%u)\n",
+                    (unsigned)block, (unsigned)remote_port,
+                    tftp_proxy_host_acks);
+            fflush(stderr);
+        }
+    }
+}
+
+static void tftp_proxy_deliver_one(void) {
+    tftp_proxy_pkt_t *p;
+    if (tftp_proxy_guest_inflight || tftp_proxy_q_count <= 0)
+        return;
+    p = &tftp_proxy_q[tftp_proxy_q_head];
+    darwin_queue_udp_reply(tftp_proxy_guest_ip, tftp_proxy_guest_port,
+                           p->remote_ip, p->remote_port,
+                           p->payload, (int)p->len);
+    tftp_proxy_guest_inflight = 1;
+    {
+        uint16_t op = ((uint16_t)p->payload[0] << 8) | p->payload[1];
+        uint16_t blk = ((uint16_t)p->payload[2] << 8) | p->payload[3];
+        static int del_logged;
+        if (del_logged < 12 || (blk % 64) == 1) {
+            del_logged++;
+            fprintf(stderr,
+                    "[TAP] TFTP deliver to guest op=%u block %u (%u bytes) q=%d\n",
+                    (unsigned)op, (unsigned)blk, (unsigned)p->len,
+                    tftp_proxy_q_count);
+            fflush(stderr);
+        }
+    }
+    tftp_proxy_q_head = (tftp_proxy_q_head + 1) % TFTP_PROXY_QMAX;
+    tftp_proxy_q_count--;
+}
+
+static int tftp_proxy_enqueue(uint32_t rip, uint16_t rport,
+                              const uint8_t *payload, int len) {
+    tftp_proxy_pkt_t *p;
+    int tail;
+    if (len < 4 || len > 516)
+        return 0;
+    if (tftp_proxy_q_count >= TFTP_PROXY_QMAX)
+        return 0;
+    tail = (tftp_proxy_q_head + tftp_proxy_q_count) % TFTP_PROXY_QMAX;
+    p = &tftp_proxy_q[tail];
+    p->remote_ip = rip;
+    p->remote_port = rport;
+    p->len = (uint16_t)len;
+    memcpy(p->payload, payload, (size_t)len);
+    tftp_proxy_q_count++;
+    return 1;
+}
+
+/* Recv TFTP on the proxy flow: host-ACK, buffer, pace to guest. */
+static void tftp_proxy_poll_flow(darwin_udp_flow_t *f) {
+    uint8_t payload[1400];
+    int got = 0;
+    for (;;) {
+        struct sockaddr_in from;
+        socklen_t fromlen = sizeof(from);
+        ssize_t n;
+        uint16_t op, blk, rport;
+        uint32_t rip;
+
+        /* Host-apply path never enqueues — skip the guest catch-up gate so a
+         * full proxy queue cannot pause ACKs mid-download. */
+        if (tftp_proxy_q_count >= TFTP_PROXY_WINDOW)
+            break; /* don't host-ACK further until guest catches up */
+
+        n = recvfrom(f->fd, payload, sizeof(payload), 0,
+                     (struct sockaddr *)&from, &fromlen);
+        if (n < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK)
+                break;
+            close(f->fd);
+            f->fd = -1;
+            tftp_proxy_reset();
+            break;
+        }
+        got = 1;
+        rip = from.sin_addr.s_addr;
+        rport = ntohs(from.sin_port);
+        f->last_used = time(NULL);
+        if (f->remote_port == 69u && rport != 69u)
+            f->remote_port = rport;
+        tftp_proxy_remote_ip = rip;
+        tftp_proxy_server_tid = rport;
+        clock_gettime(CLOCK_MONOTONIC, &tftp_proxy_last_rx);
+        tftp_proxy_last_rx_armed = 1;
+
+        if (n < 2)
+            continue;
+        op = ((uint16_t)payload[0] << 8) | payload[1];
+
+        {
+            static int tftp_rx_hex;
+            if (tftp_rx_hex < 16 && op >= 1 && op <= 6) {
+                int hi, hn = n < 48 ? (int)n : 48;
+                tftp_rx_hex++;
+                fprintf(stderr,
+                        "[TAP] TFTP RX from :%u op=%u (%zd bytes) hex:",
+                        (unsigned)rport, (unsigned)op, n);
+                for (hi = 0; hi < hn; hi++)
+                    fprintf(stderr, " %02x", payload[hi]);
+                if (n > hn)
+                    fprintf(stderr, " …");
+                if (op == 5 && n > 4)
+                    fprintf(stderr, " msg='%.*s'", (int)n - 4,
+                            (const char *)payload + 4);
+                fprintf(stderr, "\n");
+                fflush(stderr);
+            }
+        }
+
+        if (op == 3 || op == 6) {
+            /* DATA or OACK */
+            blk = (op == 6) ? 0u : (((uint16_t)payload[2] << 8) | payload[3]);
+            if (n > 516)
+                n = 516;
+
+            /* Retransmit of last applied — ACK only (wrap-safe). */
+            if (tftp_proxy_is_retransmit(blk)) {
+                tftp_proxy_host_ack(f->fd, rip, rport, blk);
+                continue;
+            }
+
+            /* Host-ACK then queue for guest CYW43 delivery. */
+            tftp_proxy_host_ack(f->fd, rip, rport, blk);
+            if (!tftp_proxy_enqueue(rip, rport, payload, (int)n)) {
+                fprintf(stderr, "[TAP] TFTP proxy queue full — drop block %u\n",
+                        (unsigned)blk);
+                fflush(stderr);
+            } else {
+                tftp_proxy_last_enqueued = blk;
+                tftp_proxy_have_enqueued = 1;
+            }
+            continue;
+        }
+        if (op == 5) {
+            /* Server ERROR while proxying. If transfer already done, ignore;
+             * otherwise log and stop keepalive (Unknown TID = session dead). */
+            static int err_drop;
+            if (tftp_proxy_transfer_done)
+                continue;
+            tftp_proxy_last_rx_armed = 0; /* stop keepalive spam */
+            if (err_drop < 8) {
+                err_drop++;
+                fprintf(stderr,
+                        "[TAP] TFTP drop ERROR from server while proxying "
+                        "(%zd bytes)",
+                        n);
+                if (n > 4)
+                    fprintf(stderr, " msg='%.*s'", (int)n - 4,
+                            (const char *)payload + 4);
+                fprintf(stderr, "\n");
+                fflush(stderr);
+            }
+            continue;
+        }
+        /* Unexpected: pass through. */
+        darwin_queue_udp_reply(f->guest_ip, f->guest_port, rip, rport,
+                               payload, (int)n);
+    }
+    /* Keepalive: re-ACK last block if idle so tftpd does not give up while
+     * host-apply is between packets or guest core0 has aborted. */
+    if (!got && !tftp_proxy_transfer_done &&
+        tftp_proxy_have_enqueued && tftp_proxy_last_rx_armed &&
+        tftp_proxy_server_tid != 0u && f->fd >= 0) {
+        struct timespec now;
+        uint64_t idle_ms;
+        if (clock_gettime(CLOCK_MONOTONIC, &now) == 0) {
+            idle_ms = (uint64_t)(now.tv_sec - tftp_proxy_last_rx.tv_sec) * 1000ull;
+            if (now.tv_nsec >= tftp_proxy_last_rx.tv_nsec)
+                idle_ms += (uint64_t)(now.tv_nsec - tftp_proxy_last_rx.tv_nsec)
+                           / 1000000ull;
+            else {
+                idle_ms -= 1000ull;
+                idle_ms += (uint64_t)(now.tv_nsec + 1000000000L
+                                     - tftp_proxy_last_rx.tv_nsec)
+                           / 1000000ull;
+            }
+            if (idle_ms >= 2000ull) {
+                static unsigned ka;
+                tftp_proxy_host_ack(f->fd, tftp_proxy_remote_ip
+                                            ? tftp_proxy_remote_ip
+                                            : f->remote_ip,
+                                    tftp_proxy_server_tid,
+                                    tftp_proxy_last_acked
+                                        ? tftp_proxy_last_acked
+                                        : tftp_proxy_last_enqueued);
+                clock_gettime(CLOCK_MONOTONIC, &tftp_proxy_last_rx);
+                if (ka < 8u || (ka % 32u) == 0u) {
+                    fprintf(stderr,
+                            "[TAP] TFTP keepalive ACK block %u (idle %llums)\n",
+                            (unsigned)tftp_proxy_last_acked,
+                            (unsigned long long)idle_ms);
+                    fflush(stderr);
+                }
+                ka++;
+            }
+        }
+    }
+    tftp_proxy_deliver_one();
+}
+
+static void queue_pending_eth(const uint8_t *frame, int len) {
+    if (len <= 0 || len > 1518) return;
+    if (darwin_rxq_count >= DARWIN_RXQ) {
+        /* Drop oldest */
+        darwin_rxq_head = (darwin_rxq_head + 1) % DARWIN_RXQ;
+        darwin_rxq_count--;
+    }
+    memcpy(darwin_rxq[darwin_rxq_tail], frame, (size_t)len);
+    darwin_rxq_len[darwin_rxq_tail] = len;
+    darwin_rxq_tail = (darwin_rxq_tail + 1) % DARWIN_RXQ;
+    darwin_rxq_count++;
+}
+
+static int dequeue_pending_eth(uint8_t *buf, int maxlen) {
+    if (darwin_rxq_count <= 0) return 0;
+    int n = darwin_rxq_len[darwin_rxq_head];
+    if (n > maxlen) n = maxlen;
+    memcpy(buf, darwin_rxq[darwin_rxq_head], (size_t)n);
+    darwin_rxq_head = (darwin_rxq_head + 1) % DARWIN_RXQ;
+    darwin_rxq_count--;
+    return n;
+}
+
+static uint16_t ipv4_checksum(const uint8_t *hdr, int len) {
+    uint32_t sum = 0;
+    for (int i = 0; i < len; i += 2)
+        sum += ((uint32_t)hdr[i] << 8) | hdr[i + 1];
+    while (sum >> 16)
+        sum = (sum & 0xFFFF) + (sum >> 16);
+    return (uint16_t)(~sum);
+}
+
+static void darwin_udp_nat_close_all(void) {
+    for (int i = 0; i < DARWIN_UDP_FLOWS; i++) {
+        if (darwin_udp_flows[i].fd >= 0) {
+            close(darwin_udp_flows[i].fd);
+            darwin_udp_flows[i].fd = -1;
+        }
+    }
+    tftp_proxy_reset();
+}
+
+static darwin_udp_flow_t *darwin_udp_flow_find(uint32_t gip, uint16_t gport,
+                                               uint32_t rip, uint16_t rport) {
+    for (int i = 0; i < DARWIN_UDP_FLOWS; i++) {
+        darwin_udp_flow_t *f = &darwin_udp_flows[i];
+        if (f->fd < 0) continue;
+        if (f->guest_ip == gip && f->guest_port == gport &&
+            f->remote_ip == rip && f->remote_port == rport)
+            return f;
+    }
+    /* TFTP TID: server replies from ephemeral port; reuse the :69 socket so
+     * host source port stays the same (else server returns Unknown transfer ID). */
+    if (rport != 69u) {
+        for (int i = 0; i < DARWIN_UDP_FLOWS; i++) {
+            darwin_udp_flow_t *f = &darwin_udp_flows[i];
+            if (f->fd < 0) continue;
+            if (f->guest_ip == gip && f->guest_port == gport &&
+                f->remote_ip == rip && f->remote_port == 69u) {
+                f->remote_port = rport;
+                return f;
+            }
+        }
+    }
+    /* Guest still ACKs to :69 after we rebound the flow to the server TID. */
+    if (rport == 69u && tftp_proxy_active && tftp_proxy_fd >= 0) {
+        for (int i = 0; i < DARWIN_UDP_FLOWS; i++) {
+            darwin_udp_flow_t *f = &darwin_udp_flows[i];
+            if (f->fd != tftp_proxy_fd) continue;
+            if (f->guest_ip == gip && f->guest_port == gport &&
+                f->remote_ip == rip)
+                return f;
+        }
+    }
+    return NULL;
+}
+
+static darwin_udp_flow_t *darwin_udp_flow_alloc(void) {
+    for (int i = 0; i < DARWIN_UDP_FLOWS; i++) {
+        if (darwin_udp_flows[i].fd < 0)
+            return &darwin_udp_flows[i];
+    }
+    /* Evict oldest — never steal the active TFTP proxy socket. */
+    int oldest = -1;
+    for (int i = 0; i < DARWIN_UDP_FLOWS; i++) {
+        if (tftp_proxy_active && darwin_udp_flows[i].fd == tftp_proxy_fd)
+            continue;
+        if (oldest < 0 ||
+            darwin_udp_flows[i].last_used < darwin_udp_flows[oldest].last_used)
+            oldest = i;
+    }
+    if (oldest < 0)
+        oldest = 0;
+    close(darwin_udp_flows[oldest].fd);
+    darwin_udp_flows[oldest].fd = -1;
+    return &darwin_udp_flows[oldest];
+}
+
+/* Build Ethernet+IPv4+UDP reply toward guest and queue it. */
+static void darwin_queue_udp_reply(uint32_t guest_ip, uint16_t guest_port,
+                                   uint32_t remote_ip, uint16_t remote_port,
+                                   const uint8_t *payload, int payload_len) {
+    if (payload_len < 0 || payload_len > 1400) return;
+
+    uint8_t frame[1518];
+    memset(frame, 0, sizeof(frame));
+    int off = 0;
+
+    memcpy(frame + off, k_guest_mac, 6); off += 6;
+    memcpy(frame + off, k_gw_mac, 6);    off += 6;
+    frame[off++] = 0x08; frame[off++] = 0x00;
+
+    int ip_off = off;
+    frame[off++] = 0x45;
+    frame[off++] = 0x00;
+    int ip_len_off = off; off += 2;
+    frame[off++] = 0x00; frame[off++] = 0x00; /* id */
+    frame[off++] = 0x40; frame[off++] = 0x00; /* DF */
+    frame[off++] = 64;
+    frame[off++] = 17; /* UDP */
+    int ip_csum_off = off; off += 2;
+    memcpy(frame + off, &remote_ip, 4); off += 4;
+    memcpy(frame + off, &guest_ip, 4);  off += 4;
+
+    int udp_off = off;
+    frame[off++] = (uint8_t)(remote_port >> 8);
+    frame[off++] = (uint8_t)(remote_port & 0xFF);
+    frame[off++] = (uint8_t)(guest_port >> 8);
+    frame[off++] = (uint8_t)(guest_port & 0xFF);
+    int udp_len_off = off; off += 2;
+    frame[off++] = 0; frame[off++] = 0; /* UDP checksum = 0 (IPv4 OK) */
+    memcpy(frame + off, payload, (size_t)payload_len);
+    off += payload_len;
+
+    int udp_total = off - udp_off;
+    int ip_total = off - ip_off;
+    frame[udp_len_off]     = (uint8_t)(udp_total >> 8);
+    frame[udp_len_off + 1] = (uint8_t)(udp_total & 0xFF);
+    frame[ip_len_off]      = (uint8_t)(ip_total >> 8);
+    frame[ip_len_off + 1]  = (uint8_t)(ip_total & 0xFF);
+
+    uint16_t csum = ipv4_checksum(frame + ip_off, 20);
+    frame[ip_csum_off]     = (uint8_t)(csum >> 8);
+    frame[ip_csum_off + 1] = (uint8_t)(csum & 0xFF);
+
+    queue_pending_eth(frame, off);
+
+    {
+        static int rx_logged;
+        if (rx_logged < 12) {
+            rx_logged++;
+            const uint8_t *r = (const uint8_t *)&remote_ip;
+            fprintf(stderr,
+                    "[TAP] UDP NAT ← %u.%u.%u.%u:%u (%d payload bytes)\n",
+                    r[0], r[1], r[2], r[3], (unsigned)remote_port, payload_len);
+            fflush(stderr);
+        }
+    }
+}
+
+/* Poll host UDP sockets; queue any replies as Ethernet frames. */
+static void darwin_udp_nat_poll(void) {
+    uint8_t payload[1400];
+    for (int i = 0; i < DARWIN_UDP_FLOWS; i++) {
+        darwin_udp_flow_t *f = &darwin_udp_flows[i];
+        if (f->fd < 0) continue;
+        if (tftp_proxy_active && f->fd == tftp_proxy_fd) {
+            tftp_proxy_poll_flow(f);
+            continue;
+        }
+        for (;;) {
+            struct sockaddr_in from;
+            socklen_t fromlen = sizeof(from);
+            ssize_t n = recvfrom(f->fd, payload, sizeof(payload), 0,
+                                 (struct sockaddr *)&from, &fromlen);
+            if (n < 0) {
+                if (errno == EAGAIN || errno == EWOULDBLOCK) break;
+                close(f->fd);
+                f->fd = -1;
+                break;
+            }
+            uint32_t rip = from.sin_addr.s_addr;
+            uint16_t rport = ntohs(from.sin_port);
+            f->last_used = time(NULL);
+            if (f->remote_port == 69u && rport != 69u)
+                f->remote_port = rport;
+            darwin_queue_udp_reply(f->guest_ip, f->guest_port,
+                                   rip, rport, payload, (int)n);
+        }
+    }
+}
+
+/* Forward guest UDP via host socket. Returns 1 if handled. */
+static int darwin_udp_nat_tx(const uint8_t *eth, int len) {
+    if (len < 14 + 20 + 8) return 0;
+    if (eth[12] != 0x08 || eth[13] != 0x00) return 0;
+
+    const uint8_t *ip = eth + 14;
+    if ((ip[0] >> 4) != 4) return 0;
+    int ihl = (ip[0] & 0x0F) * 4;
+    if (ihl < 20 || ip[9] != 17) return 0; /* not UDP */
+    if (len < 14 + ihl + 8) return 0;
+
+    const uint8_t *udp = ip + ihl;
+    uint16_t sport = ((uint16_t)udp[0] << 8) | udp[1];
+    uint16_t dport = ((uint16_t)udp[2] << 8) | udp[3];
+    uint16_t ulen  = ((uint16_t)udp[4] << 8) | udp[5];
+    int payload_len = (int)ulen - 8;
+    if (payload_len < 0) return 0;
+    if (14 + ihl + 8 + payload_len > len)
+        payload_len = len - 14 - ihl - 8;
+
+    uint32_t sip, dip;
+    memcpy(&sip, ip + 12, 4);
+    memcpy(&dip, ip + 16, 4);
+
+    /* Leave packets aimed at the virtual gateway to utun (rare). */
+    if (memcmp(&dip, k_host_ip, 4) == 0)
+        return 0;
+
+    darwin_udp_flow_t *f = darwin_udp_flow_find(sip, sport, dip, dport);
+    if (!f) {
+        f = darwin_udp_flow_alloc();
+        int s = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+        if (s < 0) {
+            fprintf(stderr, "[TAP] UDP NAT socket failed: %s\n", strerror(errno));
+            return 1; /* consumed but failed */
+        }
+        int flags = fcntl(s, F_GETFL, 0);
+        if (flags != -1)
+            fcntl(s, F_SETFL, flags | O_NONBLOCK);
+        {
+            int rcv = 1 << 20; /* 1MB — large TFTP downloads need headroom */
+            setsockopt(s, SOL_SOCKET, SO_RCVBUF, &rcv, sizeof(rcv));
+        }
+        f->fd = s;
+        f->guest_ip = sip;
+        f->guest_port = sport;
+        f->remote_ip = dip;
+        f->remote_port = dport;
+    }
+    f->last_used = time(NULL);
+
+    struct sockaddr_in dest;
+    memset(&dest, 0, sizeof(dest));
+    dest.sin_family = AF_INET;
+    dest.sin_port = htons(dport);
+    dest.sin_addr.s_addr = dip;
+
+    const uint8_t *payload = udp + 8;
+    int suppress_send = 0;
+    if (payload_len >= 2) {
+        uint16_t op = ((uint16_t)payload[0] << 8) | payload[1];
+        if (op == 1 || op == 2) {
+            /* New RRQ/WRQ — arm proxy on this flow. */
+            tftp_proxy_reset();
+            tftp_proxy_active = 1;
+            tftp_proxy_fd = f->fd;
+            tftp_proxy_guest_ip = sip;
+            tftp_proxy_guest_port = sport;
+            tftp_proxy_remote_ip = dip;
+            fprintf(stderr, "[TAP] TFTP proxy armed (RRQ/WRQ → :%u)\n",
+                    (unsigned)dport);
+            fflush(stderr);
+        } else if (op == 4 && payload_len >= 4 && tftp_proxy_active &&
+                   f->fd == tftp_proxy_fd) {
+            /* Guest ACK — already host-ACKed; advance guest queue only. */
+            uint16_t blk = ((uint16_t)payload[2] << 8) | payload[3];
+            tftp_proxy_last_guest_ack = blk;
+            tftp_proxy_guest_acks++;
+            tftp_proxy_guest_inflight = 0;
+            suppress_send = 1;
+            if (tftp_proxy_guest_acks <= 8 || (tftp_proxy_guest_acks % 64) == 0) {
+                fprintf(stderr,
+                        "[TAP] TFTP guest-ACK block %u (host already ACKed; "
+                        "q=%d)\n",
+                        (unsigned)blk, tftp_proxy_q_count);
+                fflush(stderr);
+            }
+            tftp_proxy_deliver_one();
+        } else if (op == 5 && tftp_proxy_active && f->fd == tftp_proxy_fd) {
+            /* Guest ERROR (timeout/abort) would kill tftpd while host-apply
+             * still owns the session — drop it. */
+            static int guest_err;
+            suppress_send = 1;
+            if (guest_err < 8) {
+                guest_err++;
+                fprintf(stderr,
+                        "[TAP] TFTP drop guest ERROR while host-proxying\n");
+                fflush(stderr);
+            }
+        }
+    }
+    if (!suppress_send) {
+        ssize_t n = sendto(f->fd, payload, (size_t)payload_len, 0,
+                           (struct sockaddr *)&dest, sizeof(dest));
+        if (n < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+            fprintf(stderr, "[TAP] UDP NAT sendto failed: %s\n", strerror(errno));
+        } else {
+            static int tx_logged;
+            int is_tftp = (dport == 69u) ||
+                          (payload_len >= 2 &&
+                           (((uint16_t)payload[0] << 8) | payload[1]) <= 6);
+            if (tx_logged < 24 || is_tftp) {
+                if (tx_logged < 24)
+                    tx_logged++;
+                const uint8_t *d = (const uint8_t *)&dip;
+                fprintf(stderr,
+                        "[TAP] UDP NAT → %u.%u.%u.%u:%u (%d payload bytes)\n",
+                        d[0], d[1], d[2], d[3], (unsigned)dport, payload_len);
+                if (is_tftp && payload_len > 0) {
+                    int i, hn = payload_len < 48 ? payload_len : 48;
+                    fprintf(stderr, "[TAP] TFTP TX hex:");
+                    for (i = 0; i < hn; i++)
+                        fprintf(stderr, " %02x", payload[i]);
+                    if (payload_len > hn)
+                        fprintf(stderr, " …");
+                    fprintf(stderr, "\n");
+                }
+                fflush(stderr);
+            }
+        }
+    }
+    return 1;
+}
+
+/* Answer ARP who-has 192.168.4.1 — return 1 if handled. */
+static int darwin_handle_arp(const uint8_t *eth, int len) {
+    if (len < 42) return 0;
+    if (eth[12] != 0x08 || eth[13] != 0x06) return 0; /* not ARP */
+
+    const uint8_t *arp = eth + 14;
+    uint16_t op = ((uint16_t)arp[6] << 8) | arp[7];
+    if (op != 1) return 0; /* not request */
+
+    const uint8_t *tpa = arp + 24; /* target protocol address */
+    if (memcmp(tpa, k_host_ip, 4) != 0) return 0;
+
+    uint8_t reply[42];
+    memset(reply, 0, sizeof(reply));
+    /* Ethernet: dst=requester, src=gw */
+    memcpy(reply, eth + 6, 6);
+    memcpy(reply + 6, k_gw_mac, 6);
+    reply[12] = 0x08;
+    reply[13] = 0x06;
+    /* ARP reply */
+    reply[14] = 0x00; reply[15] = 0x01; /* HTYPE Ethernet */
+    reply[16] = 0x08; reply[17] = 0x00; /* PTYPE IPv4 */
+    reply[18] = 6;    reply[19] = 4;    /* HLEN PLEN */
+    reply[20] = 0x00; reply[21] = 0x02; /* OPER reply */
+    memcpy(reply + 22, k_gw_mac, 6);    /* SHA */
+    memcpy(reply + 28, k_host_ip, 4);   /* SPA */
+    memcpy(reply + 32, eth + 6, 6);     /* THA = requester MAC */
+    memcpy(reply + 38, arp + 14, 4);    /* TPA = requester IP (SPA of req) */
+
+    queue_pending_eth(reply, 42);
+    return 1;
+}
+
+static int darwin_configure_utun(const char *ifname) {
+    char cmd[256];
+    /* Point-to-point: local 192.168.4.1, peer 192.168.4.2 */
+    snprintf(cmd, sizeof(cmd),
+             "ifconfig %s inet %s %s netmask %s up 2>/dev/null",
+             ifname, TAP_HOST_IP, TAP_PEER_IP, TAP_NETMASK);
+    if (run_cmd(cmd) != 0) {
+        fprintf(stderr, "[TAP] ifconfig failed (need root?). Manual:\n");
+        fprintf(stderr, "[TAP]   sudo ifconfig %s inet %s %s netmask %s up\n",
+                ifname, TAP_HOST_IP, TAP_PEER_IP, TAP_NETMASK);
+        return -1;
+    }
+    fprintf(stderr, "[TAP] Configured %s as %s (peer %s)\n",
+            ifname, TAP_HOST_IP, TAP_PEER_IP);
+    return 0;
+}
+
+static void darwin_try_pf_nat(void) {
+    /* Optional: TCP/ICMP via kernel. UDP uses userspace NAT regardless. */
+    const char *script = getenv("BRAMBLE_PF_NAT");
+    char local[512];
+    if (!script || !script[0]) {
+        static const char *candidates[] = {
+            "scripts/macos-cyw43-pf-nat.sh",
+            "../Bramble/scripts/macos-cyw43-pf-nat.sh",
+            NULL
+        };
+        for (int i = 0; candidates[i]; i++) {
+            if (access(candidates[i], X_OK) == 0 || access(candidates[i], R_OK) == 0) {
+                script = candidates[i];
+                break;
+            }
+        }
+    }
+    if (script && script[0]) {
+        snprintf(local, sizeof(local), "sh '%s' enable 2>/dev/null", script);
+        if (run_cmd(local) == 0) {
+            fprintf(stderr, "[TAP] pf NAT enabled via %s (TCP/ICMP; UDP is userspace)\n",
+                    script);
+            return;
+        }
+    }
+    fprintf(stderr, "[TAP] pf NAT optional (UDP DNS/NTP/TFTP use userspace NAT)\n");
+}
+
+int tapif_open(const char *name) {
+    (void)name; /* utun unit is assigned by the kernel */
+
+    for (int i = 0; i < DARWIN_UDP_FLOWS; i++)
+        darwin_udp_flows[i].fd = -1;
+    darwin_rxq_head = darwin_rxq_tail = darwin_rxq_count = 0;
+
+    int fd = socket(PF_SYSTEM, SOCK_DGRAM, SYSPROTO_CONTROL);
+    if (fd < 0) {
+        fprintf(stderr, "[TAP] utun socket failed: %s\n", strerror(errno));
+        return -1;
+    }
+
+    struct ctl_info info;
+    memset(&info, 0, sizeof(info));
+    strncpy(info.ctl_name, UTUN_CONTROL_NAME, sizeof(info.ctl_name) - 1);
+    if (ioctl(fd, CTLIOCGINFO, &info) < 0) {
+        fprintf(stderr, "[TAP] CTLIOCGINFO failed: %s\n", strerror(errno));
+        close(fd);
+        return -1;
+    }
+
+    struct sockaddr_ctl addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sc_len = sizeof(addr);
+    addr.sc_family = AF_SYSTEM;
+    addr.ss_sysaddr = AF_SYS_CONTROL;
+    addr.sc_id = info.ctl_id;
+    addr.sc_unit = 0; /* kernel picks next utunN */
+
+    if (connect(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        fprintf(stderr, "[TAP] utun connect failed: %s\n", strerror(errno));
+        close(fd);
+        return -1;
+    }
+
+    char ifname[IFNAMSIZ];
+    socklen_t ifname_len = sizeof(ifname);
+    if (getsockopt(fd, SYSPROTO_CONTROL, UTUN_OPT_IFNAME, ifname, &ifname_len) < 0) {
+        fprintf(stderr, "[TAP] UTUN_OPT_IFNAME failed: %s\n", strerror(errno));
+        close(fd);
+        return -1;
+    }
+
+    int flags = fcntl(fd, F_GETFL, 0);
+    if (flags != -1)
+        fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+
+    memset(utun_ifname, 0, sizeof(utun_ifname));
+    strncpy(utun_ifname, ifname, sizeof(utun_ifname) - 1);
+    darwin_active = 1;
+    darwin_utun_rx_ok = 1;
+
+    fprintf(stderr,
+            "[TAP] macOS utun '%s' opened (fd=%d) — UDP userspace NAT + L3 bridge\n",
+            utun_ifname, fd);
+
+    darwin_configure_utun(utun_ifname);
+    darwin_try_pf_nat();
+    return fd;
+}
+
+void tapif_close(int fd) {
+    if (fd >= 0) {
+        if (darwin_active && utun_ifname[0]) {
+            fprintf(stderr, "[TAP] Closed utun '%s'\n", utun_ifname);
+        }
+        darwin_udp_nat_close_all();
+        darwin_rxq_count = 0;
+        darwin_active = 0;
+        utun_ifname[0] = '\0';
+        close(fd);
+    }
+}
+
+void tapif_service(int fd) {
+    (void)fd;
+    if (fd < 0) return;
+    darwin_udp_nat_poll();
+}
+
+int tapif_read(int fd, uint8_t *buf, int maxlen) {
+    if (fd < 0) return -1;
+
+    darwin_udp_nat_poll();
+
+    int q = dequeue_pending_eth(buf, maxlen);
+    if (q > 0) return q;
+
+    /* utun RX is optional (TCP/ICMP via pf). UDP NAT does not need it.
+     * A hard utun read error must not kill the bridge — that dropped ARP/DNS. */
+    if (!darwin_utun_rx_ok)
+        return 0;
+
+    uint8_t raw[4 + 1500];
+    ssize_t n = read(fd, raw, sizeof(raw));
+    if (n < 0) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR)
+            return 0;
+        static int utun_err_logged;
+        if (utun_err_logged < 3) {
+            utun_err_logged++;
+            fprintf(stderr,
+                    "[TAP] utun read: %s — continuing with UDP NAT only\n",
+                    strerror(errno));
+            fflush(stderr);
+        }
+        if (errno == EBADF)
+            return -1;
+        darwin_utun_rx_ok = 0;
+        return 0;
+    }
+    if (n <= 4) return 0;
+
+    uint32_t af;
+    memcpy(&af, raw, 4);
+    af = ntohl(af);
+    if (af != AF_INET) return 0; /* ignore IPv6 for now */
+
+    int ip_len = (int)n - 4;
+    if (14 + ip_len > maxlen) return 0;
+    if (ip_len < 20) return 0;
+
+    /* Build Ethernet frame for guest */
+    memcpy(buf, k_guest_mac, 6);
+    memcpy(buf + 6, k_gw_mac, 6);
+    buf[12] = 0x08;
+    buf[13] = 0x00;
+    memcpy(buf + 14, raw + 4, (size_t)ip_len);
+    return 14 + ip_len;
+}
+
+int tapif_write(int fd, const uint8_t *buf, int len) {
+    if (fd < 0) return -1;
+    if (len < 14) return -1;
+
+    if (darwin_handle_arp(buf, len)) {
+        return len; /* consumed; reply queued for tapif_read */
+    }
+
+    if (buf[12] != 0x08 || buf[13] != 0x00) {
+        return len; /* drop non-IPv4 quietly */
+    }
+
+    /* UDP (DNS/NTP/TFTP): userspace NAT — does not need pf */
+    if (darwin_udp_nat_tx(buf, len))
+        return len;
+
+    /* Other IPv4 (TCP/ICMP): best-effort via utun + optional pf */
+    int ip_len = len - 14;
+    if (ip_len < 20) return -1;
+
+    uint8_t raw[4 + 1500];
+    if (ip_len > 1500) ip_len = 1500;
+    uint32_t af = htonl(AF_INET);
+    memcpy(raw, &af, 4);
+    memcpy(raw + 4, buf + 14, (size_t)ip_len);
+
+    int total = 0;
+    int want = 4 + ip_len;
+    while (total < want) {
+        ssize_t n = write(fd, raw + total, (size_t)(want - total));
+        if (n < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                return total > 4 ? len : 0;
+            }
+            return -1;
+        }
+        total += (int)n;
+    }
+    return len;
+}
+
+#else /* !linux && !apple */
+
+int tapif_open(const char *name) {
+    (void)name;
+    fprintf(stderr, "[TAP] Host network bridge not supported on this platform\n");
+    return -1;
+}
+
+void tapif_close(int fd) {
+    if (fd >= 0) close(fd);
+}
+
+int tapif_read(int fd, uint8_t *buf, int maxlen) {
+    (void)fd; (void)buf; (void)maxlen;
+    return -1;
+}
+
+int tapif_write(int fd, const uint8_t *buf, int len) {
+    (void)fd; (void)buf; (void)len;
+    return -1;
+}
+
+void tapif_service(int fd) {
+    (void)fd;
+}
+
+
+#endif


### PR DESCRIPTION
## Summary
- macOS **utun** CYW43 host bridge + userspace UDP NAT (DNS/NTP/TFTP)
- TAP **host-ACK** for TFTP so slow guest ACK does not kill LAN transfers
- Optional `scripts/macos-cyw43-pf-nat.sh` for TCP/ICMP
- Docs: `docs/MACOS-WIFI.md`
- Small Darwin **corepool** build fixes (`unistd.h` / condattr)

**Excluded:** MegaFlash/a2bus TFTP host-apply callbacks, Apple/MAME.

## Test plan
- [ ] `make -C build bramble bramble_tests && ./build/bramble_tests`
- [ ] Linux: `-wifi -tap` still bridges
- [ ] macOS: `-wifi -tap` utun + UDP DNS/NTP
- [ ] Optional: TFTP RRQ against a LAN tftpd with host-ACK logs