### PR TITLE
feat(spi): host file/mmap backing for -spi-flash1/2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ set(EMU_SOURCES
     src/rom.c
     src/uart.c
     src/spi.c
+    src/spi_flash.c
     src/i2c.c
     src/pwm.c
     src/dma.c

--- a/docs/SPI-FLASH.md
+++ b/docs/SPI-FLASH.md
@@ -1,0 +1,11 @@
+# Host SPI flash backing
+
+Map one or two SPI NOR images to host files for firmware that talks to external flash:
+
+```bash
+./bramble firmware.uf2 -spi-flash1 flash/spi-flash1.bin -spi-flash1-size 64
+./bramble firmware.uf2 -spi-flash2 flash/spi-flash2.bin -spi-flash2-size 64
+```
+
+Defaults create `flash/spi-flash{1,2}.bin` at 64 MB (sizes are multiples of 32 MB, max 256).
+API: `spi_flash_configure` / `spi_flash_set_size` / `spi_flash_read` / `spi_flash_write` / `spi_flash_close`.

--- a/include/corepool.h
+++ b/include/corepool.h
@@ -3,6 +3,7 @@
 
 #include <pthread.h>
 #include <stdint.h>
+#include <unistd.h>
 
 /* ========================================================================
  * Core Pool — Host-Threaded Execution & Multi-Instance Coordination

--- a/include/spi_flash.h
+++ b/include/spi_flash.h
@@ -1,0 +1,37 @@
+#ifndef SPI_FLASH_H
+#define SPI_FLASH_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef _WIN32
+#include <BaseTdefs.h>
+typedef SSIZE_T ssize_t;
+#else
+#include <sys/types.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Configure SPI flash chip backing (path NULL/empty → default file). */
+void spi_flash_configure(unsigned chip, const char *path);
+
+/* Set chip capacity in MB (rounded up to a multiple of 32, max 256). */
+void spi_flash_set_size(unsigned chip, uint32_t size_mb);
+
+/* Close all chips and release backing resources. */
+void spi_flash_close(void);
+
+/* Read len bytes at offset. Returns bytes read, or -1 on error. */
+ssize_t spi_flash_read(unsigned chip, uint64_t offset, void *buf, size_t len);
+
+/* Write len bytes at offset. Returns bytes written, or -1 on error. */
+ssize_t spi_flash_write(unsigned chip, uint64_t offset, const void *buf, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SPI_FLASH_H */

--- a/src/corepool.c
+++ b/src/corepool.c
@@ -28,6 +28,15 @@
 #include "timer.h"
 #include "usb.h"
 
+/* macOS pthread_cond_timedwait uses CLOCK_REALTIME; no setclock API */
+#if defined(__APPLE__)
+#define COREPOOL_COND_CLOCK_ID CLOCK_REALTIME
+#define COREPOOL_COND_USE_SETCLOCK 0
+#else
+#define COREPOOL_COND_CLOCK_ID CLOCK_MONOTONIC
+#define COREPOOL_COND_USE_SETCLOCK 1
+#endif
+
 /*
  * Each host thread keeps the big lock for a short burst of guest work before
  * yielding. This cuts mutex/scheduler overhead without changing interrupt
@@ -71,7 +80,9 @@ void corepool_init(void) {
 
     pthread_condattr_t attr;
     pthread_condattr_init(&attr);
-    pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
+#if COREPOOL_COND_USE_SETCLOCK
+    pthread_condattr_setclock(&attr, COREPOOL_COND_CLOCK_ID);
+#endif
     pthread_cond_init(&corepool.wfi_cond, &attr);
     pthread_condattr_destroy(&attr);
 
@@ -287,7 +298,7 @@ static void *core_thread_fn(void *arg) {
             if (cores[core_id].is_halted) {
                 /* Halted core: sleep briefly then re-check (may be re-launched) */
                 struct timespec ts;
-                clock_gettime(CLOCK_MONOTONIC, &ts);
+                clock_gettime(COREPOOL_COND_CLOCK_ID, &ts);
                 ts.tv_nsec += 1000000;  /* 1ms */
                 if (ts.tv_nsec >= 1000000000) {
                     ts.tv_sec++;
@@ -317,7 +328,7 @@ static void *core_thread_fn(void *arg) {
                 struct timespec end;
 
                 clock_gettime(CLOCK_MONOTONIC, &start);
-                ts = start;
+                clock_gettime(COREPOOL_COND_CLOCK_ID, &ts);
                 ts.tv_nsec += 1000000;  /* 1ms */
                 if (ts.tv_nsec >= 1000000000) {
                     ts.tv_sec++;
@@ -336,11 +347,10 @@ static void *core_thread_fn(void *arg) {
                     systick_tick_for_core(core_id, (uint32_t)elapsed_cycles);
                 }
 
-                /* If every active core is sleeping/halted, use host elapsed time
-                 * as a fallback so timer-driven wakeups still happen. */
-                if (core_id == CORE0 &&
-                    (num_active_cores == 1 || cores[CORE1].is_wfi || cores[CORE1].is_halted) &&
-                    elapsed_us > 0) {
+                /* Any core in WFI/WFE: advance shared TIMER by host elapsed so
+                 * sleep_until/alarms work while the peer core stays busy (e.g.
+                 * cyw43_arch_init on core0 + BusLoop on core1). */
+                if (elapsed_us > 0) {
                     timer_tick(elapsed_us);
                     rtc_tick(elapsed_us);
                 }

--- a/src/main.c
+++ b/src/main.c
@@ -50,6 +50,7 @@ typedef enum { ARCH_M0PLUS, ARCH_RV32, ARCH_M33 } arch_t;
 #include "pio.h"
 #include "gdb.h"
 #include "usb.h"
+#include "spi_flash.h"
 #include "rtc.h"
 #include "netbridge.h"
 #include "wire.h"
@@ -323,6 +324,11 @@ static void reboot_from_watchdog(const char *tap_name,
  * Main Entry Point
  * ============================================================================ */
 
+static int cli_next_arg_is_value(int argc, char **argv, int i) {
+    return (i + 1 < argc && argv[i + 1][0] != '-');
+}
+
+
 int main(int argc, char **argv) {
     if (argc < 2) {
         fprintf(stderr, "Usage: %s <firmware.uf2> [options]\n", argv[0]);
@@ -336,6 +342,10 @@ int main(int argc, char **argv) {
         fprintf(stderr, "  -asm       Show assembly instruction tracing\n");
         fprintf(stderr, "  -status    Print periodic status updates\n");
         fprintf(stderr, "  -stdin     Enable stdin polling for guest console input\n");
+        fprintf(stderr, "  -spi-flash1 [path]       SPI flash chip #1 backing file (default: flash/spi-flash1.bin)\n");
+        fprintf(stderr, "  -spi-flash1-size <MB>    SPI chip #1 size in MB (default: 64, multiple of 32)\n");
+        fprintf(stderr, "  -spi-flash2 [path]       SPI flash chip #2 backing file (default: flash/spi-flash2.bin)\n");
+        fprintf(stderr, "  -spi-flash2-size <MB>    SPI chip #2 size in MB (default: 64, multiple of 32)\n");
         fprintf(stderr, "  -gdb [port] Start GDB server (default port: %d)\n", GDB_DEFAULT_PORT);
         fprintf(stderr, "  -clock <MHz> Set CPU clock frequency (default: 1, real: 125)\n");
         fprintf(stderr, "  -cores <N|auto> Active cores per instance (1, 2, or auto; default: 1)\n");
@@ -580,7 +590,27 @@ int main(int argc, char **argv) {
             if (i + 1 < argc) {
                 wire_add_link(argv[++i], WIRE_MSG_ETH_FRAME, 0);
             }
-        } else if (strcmp(argv[i], "-wifi") == 0) {
+                } else if (strcmp(argv[i], "-spi-flash1") == 0) {
+            const char *path = NULL;
+            if (cli_next_arg_is_value(argc, argv, i)) {
+                path = argv[++i];
+            }
+            spi_flash_configure(0u, path);
+        } else if (strcmp(argv[i], "-spi-flash1-size") == 0) {
+            if (i + 1 < argc) {
+                spi_flash_set_size(0u, (uint32_t)atoi(argv[++i]));
+            }
+        } else if (strcmp(argv[i], "-spi-flash2") == 0) {
+            const char *path = NULL;
+            if (cli_next_arg_is_value(argc, argv, i)) {
+                path = argv[++i];
+            }
+            spi_flash_configure(1u, path);
+        } else if (strcmp(argv[i], "-spi-flash2-size") == 0) {
+            if (i + 1 < argc) {
+                spi_flash_set_size(1u, (uint32_t)atoi(argv[++i]));
+            }
+} else if (strcmp(argv[i], "-wifi") == 0) {
             cyw43.enabled = 1;
         } else if (strcmp(argv[i], "-tap") == 0) {
             if (i + 1 < argc) {

--- a/src/spi_flash.c
+++ b/src/spi_flash.c
@@ -1,0 +1,372 @@
+#include "spi_flash.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if !defined(_WIN32)
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#else
+#include <io.h>
+#endif
+
+/* Winbond W25Q512JV default: 512 Mbit (64 MB). */
+#define SPI_FLASH_CHIP_COUNT       2u
+#define SPI_FLASH_DEFAULT_CHIP_MB  64u
+#define SPI_FLASH_UNIT_MB          32u
+#define SPI_FLASH_MAX_CHIP_MB      256u
+#define SPI_FLASH_DEFAULT_DIR      "flash"
+#define SPI_FLASH1_DEFAULT         "flash/spi-flash1.bin"
+#define SPI_FLASH2_DEFAULT         "flash/spi-flash2.bin"
+
+typedef struct {
+    int enabled;
+    int use_default_path;
+    char *path;
+    uint32_t size_mb;
+    FILE *fp;
+#if !defined(_WIN32)
+    uint8_t *map;
+    size_t map_bytes;
+#endif
+} spi_flash_chip_t;
+
+typedef struct {
+    int valid;
+    uint64_t next_off;
+} spi_flash_seq_t;
+
+static spi_flash_chip_t spi_flash_chips[SPI_FLASH_CHIP_COUNT] = {
+    { .size_mb = SPI_FLASH_DEFAULT_CHIP_MB },
+    { .size_mb = SPI_FLASH_DEFAULT_CHIP_MB },
+};
+
+static spi_flash_seq_t spi_flash_seq[SPI_FLASH_CHIP_COUNT];
+static int spi_flash_logged;
+static int spi_flash_dir_created;
+static uint32_t spi_flash_fflush_pending;
+static uint32_t spi_flash_msync_pending[SPI_FLASH_CHIP_COUNT];
+
+static uint64_t spi_flash_chip_bytes(const spi_flash_chip_t *chip) {
+    return (uint64_t)chip->size_mb * 1024u * 1024u;
+}
+
+static uint32_t spi_flash_normalize_size_mb(uint32_t size_mb) {
+    if (size_mb < SPI_FLASH_UNIT_MB) {
+        size_mb = SPI_FLASH_UNIT_MB;
+    }
+    if (size_mb % SPI_FLASH_UNIT_MB != 0u) {
+        size_mb = ((size_mb + SPI_FLASH_UNIT_MB - 1u) / SPI_FLASH_UNIT_MB) *
+                  SPI_FLASH_UNIT_MB;
+    }
+    if (size_mb > SPI_FLASH_MAX_CHIP_MB) {
+        size_mb = SPI_FLASH_MAX_CHIP_MB;
+    }
+    return size_mb;
+}
+
+static void spi_flash_ensure_default_dir(void) {
+#if !defined(_WIN32)
+    if (!spi_flash_dir_created++) {
+        mkdir(SPI_FLASH_DEFAULT_DIR, 0755);
+    }
+#endif
+}
+
+static void spi_flash_resolve_path(unsigned chip) {
+    if (chip >= SPI_FLASH_CHIP_COUNT) {
+        return;
+    }
+    spi_flash_chip_t *c = &spi_flash_chips[chip];
+    if (!c->enabled || c->path != NULL) {
+        return;
+    }
+    if (!c->use_default_path) {
+        return;
+    }
+    spi_flash_ensure_default_dir();
+    c->path = strdup(chip == 0u ? SPI_FLASH1_DEFAULT : SPI_FLASH2_DEFAULT);
+}
+
+static int spi_flash_ensure_file_size(spi_flash_chip_t *c) {
+    if (c->fp == NULL) {
+        return 0;
+    }
+    size_t sz = (size_t)c->size_mb * 1024u * 1024u;
+#if !defined(_WIN32)
+    int fd = fileno(c->fp);
+    if (fd < 0) {
+        return 0;
+    }
+    struct stat st;
+    if (fstat(fd, &st) != 0) {
+        return 0;
+    }
+    if ((size_t)st.st_size < sz && ftruncate(fd, (off_t)sz) != 0) {
+        return 0;
+    }
+#else
+    if (_chsize(_fileno(c->fp), (__int64)sz) != 0) {
+        return 0;
+    }
+#endif
+    return 1;
+}
+
+#if !defined(_WIN32)
+static int spi_flash_map_chip(unsigned chip) {
+    if (chip >= SPI_FLASH_CHIP_COUNT) {
+        return 0;
+    }
+    spi_flash_chip_t *c = &spi_flash_chips[chip];
+    if (c->map != NULL) {
+        return 1;
+    }
+    if (c->fp == NULL) {
+        return 0;
+    }
+    if (!spi_flash_ensure_file_size(c)) {
+        return 0;
+    }
+    int fd = fileno(c->fp);
+    if (fd < 0) {
+        return 0;
+    }
+    size_t sz = (size_t)c->size_mb * 1024u * 1024u;
+    void *p = mmap(NULL, sz, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (p == MAP_FAILED) {
+        return 0;
+    }
+    c->map = (uint8_t *)p;
+    c->map_bytes = sz;
+    static int map_logged;
+    if (!map_logged++) {
+        fprintf(stderr, "[SPI] flash mmap enabled for fast backing I/O\n");
+    }
+    return 1;
+}
+#endif
+
+static FILE *spi_flash_open_chip(unsigned chip) {
+    if (chip >= SPI_FLASH_CHIP_COUNT) {
+        return NULL;
+    }
+    spi_flash_chip_t *c = &spi_flash_chips[chip];
+    if (!c->enabled) {
+        return NULL;
+    }
+    spi_flash_resolve_path(chip);
+    if (c->path == NULL || c->path[0] == '\0') {
+        return NULL;
+    }
+    if (c->fp != NULL) {
+        return c->fp;
+    }
+    FILE *fp = fopen(c->path, "r+b");
+    if (fp == NULL) {
+        fp = fopen(c->path, "w+b");
+    }
+    if (fp == NULL) {
+        fprintf(stderr, "[SPI] flash %u: cannot open %s: %s\n",
+                chip + 1u, c->path, strerror(errno));
+        return NULL;
+    }
+    c->fp = fp;
+    (void)spi_flash_ensure_file_size(c);
+#if !defined(_WIN32)
+    (void)spi_flash_map_chip(chip);
+#endif
+    if (!spi_flash_logged++) {
+        fprintf(stderr, "[SPI] SPI flash backing enabled\n");
+    }
+    fprintf(stderr, "[SPI]   spi-flash%u: %s (%uMB)\n",
+            chip + 1u, c->path, c->size_mb);
+    return fp;
+}
+
+void spi_flash_configure(unsigned chip, const char *path) {
+    if (chip >= SPI_FLASH_CHIP_COUNT) {
+        return;
+    }
+    spi_flash_chip_t *c = &spi_flash_chips[chip];
+    c->enabled = 1;
+    if (c->path != NULL) {
+        free(c->path);
+        c->path = NULL;
+    }
+    if (path != NULL && path[0] != '\0') {
+        c->path = strdup(path);
+        c->use_default_path = 0;
+    } else {
+        c->use_default_path = 1;
+    }
+}
+
+void spi_flash_set_size(unsigned chip, uint32_t size_mb) {
+    if (chip >= SPI_FLASH_CHIP_COUNT || size_mb == 0u) {
+        return;
+    }
+    spi_flash_chips[chip].size_mb = spi_flash_normalize_size_mb(size_mb);
+}
+
+static int spi_flash_bounds_ok(unsigned chip, uint64_t offset, size_t len) {
+    if (chip >= SPI_FLASH_CHIP_COUNT || len == 0u) {
+        return 0;
+    }
+    if (!spi_flash_chips[chip].enabled) {
+        return 0;
+    }
+    uint64_t chip_bytes = spi_flash_chip_bytes(&spi_flash_chips[chip]);
+    if (offset >= chip_bytes) {
+        return 0;
+    }
+    if (offset + (uint64_t)len > chip_bytes) {
+        return 0;
+    }
+    return 1;
+}
+
+ssize_t spi_flash_read(unsigned chip, uint64_t offset, void *buf, size_t len) {
+    if (buf == NULL) {
+        return -1;
+    }
+    if (len == 0u) {
+        return 0;
+    }
+    if (!spi_flash_bounds_ok(chip, offset, len)) {
+        return -1;
+    }
+    if (spi_flash_open_chip(chip) == NULL) {
+        return -1;
+    }
+
+    spi_flash_chip_t *c = &spi_flash_chips[chip];
+    spi_flash_seq_t *seq = &spi_flash_seq[chip];
+
+#if !defined(_WIN32)
+    if (c->map != NULL && offset + len <= c->map_bytes) {
+        memcpy(buf, c->map + offset, len);
+        seq->valid = 1;
+        seq->next_off = offset + len;
+        return (ssize_t)len;
+    }
+#endif
+
+    if (c->fp != NULL) {
+        if (!(seq->valid && seq->next_off == offset)) {
+            if (fseeko(c->fp, (off_t)offset, SEEK_SET) != 0) {
+                return -1;
+            }
+        }
+        size_t n = fread(buf, 1, len, c->fp);
+        if (n < len) {
+            memset((uint8_t *)buf + n, 0, len - n);
+        }
+        seq->valid = 1;
+        seq->next_off = offset + len;
+        return (ssize_t)len;
+    }
+
+    return -1;
+}
+
+ssize_t spi_flash_write(unsigned chip, uint64_t offset, const void *buf, size_t len) {
+    if (buf == NULL) {
+        return -1;
+    }
+    if (len == 0u) {
+        return 0;
+    }
+    if (!spi_flash_bounds_ok(chip, offset, len)) {
+        return -1;
+    }
+    if (spi_flash_open_chip(chip) == NULL) {
+        return -1;
+    }
+
+    spi_flash_chip_t *c = &spi_flash_chips[chip];
+    spi_flash_seq_t *seq = &spi_flash_seq[chip];
+
+#if !defined(_WIN32)
+    if (c->map != NULL && offset + len <= c->map_bytes) {
+        memcpy(c->map + offset, buf, len);
+        seq->valid = 1;
+        seq->next_off = offset + len;
+        if (++spi_flash_msync_pending[chip] >= 4096u) {
+            size_t sync_len = 4096u * 512u;
+            uint64_t sync_off = offset + len;
+            if (sync_off > sync_len) {
+                sync_off -= sync_len;
+            } else {
+                sync_off = 0;
+            }
+            if (sync_off + sync_len > c->map_bytes) {
+                sync_len = c->map_bytes - (size_t)sync_off;
+            }
+            if (sync_len > 0u) {
+                (void)msync(c->map + sync_off, sync_len, MS_ASYNC);
+            }
+            spi_flash_msync_pending[chip] = 0u;
+        }
+        return (ssize_t)len;
+    }
+#endif
+
+    if (c->fp != NULL) {
+        if (!(seq->valid && seq->next_off == offset)) {
+            if (fseeko(c->fp, (off_t)offset, SEEK_SET) != 0) {
+                fprintf(stderr,
+                        "[SPI] flash write seek failed chip=%u off=%llu\n",
+                        chip, (unsigned long long)offset);
+                return -1;
+            }
+        }
+        if (fwrite(buf, 1, len, c->fp) != len) {
+            fprintf(stderr, "[SPI] flash write short chip=%u off=%llu len=%zu\n",
+                    chip, (unsigned long long)offset, len);
+            return -1;
+        }
+        seq->valid = 1;
+        seq->next_off = offset + len;
+        if (++spi_flash_fflush_pending >= 256u) {
+            fflush(c->fp);
+            spi_flash_fflush_pending = 0u;
+        }
+        return (ssize_t)len;
+    }
+
+    return -1;
+}
+
+void spi_flash_close(void) {
+    for (unsigned chip = 0; chip < SPI_FLASH_CHIP_COUNT; chip++) {
+        spi_flash_chip_t *c = &spi_flash_chips[chip];
+#if !defined(_WIN32)
+        if (c->map != NULL) {
+            (void)msync(c->map, c->map_bytes, MS_SYNC);
+            munmap(c->map, c->map_bytes);
+            c->map = NULL;
+            c->map_bytes = 0;
+        }
+#endif
+        if (c->fp != NULL) {
+            fflush(c->fp);
+            fclose(c->fp);
+            c->fp = NULL;
+        }
+        free(c->path);
+        c->path = NULL;
+        c->enabled = 0;
+        c->use_default_path = 0;
+        c->size_mb = SPI_FLASH_DEFAULT_CHIP_MB;
+        spi_flash_seq[chip].valid = 0;
+        spi_flash_msync_pending[chip] = 0u;
+    }
+    spi_flash_fflush_pending = 0u;
+    spi_flash_logged = 0;
+    spi_flash_dir_created = 0;
+}


### PR DESCRIPTION
## Summary
- New `spi_flash.c` / `spi_flash.h`: 2 chips, mmap, default `flash/spi-flash{1,2}.bin`
- CLI: `-spi-flash1/2` and `-spi-flash1/2-size`
- Docs: `docs/SPI-FLASH.md`

**Excluded:** MegaFlash ProDOS units, USB guest stubs, XMODEM.

## Test plan
- [ ] `make -C build bramble bramble_tests && ./build/bramble_tests`
- [ ] `./bramble fw.uf2 -spi-flash1 /tmp/t.bin -spi-flash1-size 64` creates/maps file