### PR TITLE
feat(usb): generic -usb-console TCP/PTY CDC host bridge

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ set(EMU_SOURCES
     src/pio.c
     src/gdb.c
     src/usb.c
+    src/usb_console.c
     src/rtc.c
     src/netbridge.c
     src/wire.c

--- a/docs/USB-CONSOLE.md
+++ b/docs/USB-CONSOLE.md
@@ -1,0 +1,13 @@
+# USB CDC host console
+
+Bidirectional console over the emulated USB CDC device:
+
+```bash
+./bramble firmware.uf2 -usb-console 9999
+nc localhost 9999
+
+./bramble firmware.uf2 -usb-console pty
+screen /tmp/bramble-usb-console 115200
+```
+
+`-usb-serial [path]` is an alias for `-usb-console pty[:path]`.

--- a/include/corepool.h
+++ b/include/corepool.h
@@ -3,6 +3,7 @@
 
 #include <pthread.h>
 #include <stdint.h>
+#include <unistd.h>
 
 /* ========================================================================
  * Core Pool — Host-Threaded Execution & Multi-Instance Coordination

--- a/include/usb_console.h
+++ b/include/usb_console.h
@@ -1,0 +1,50 @@
+#ifndef USB_CONSOLE_H
+#define USB_CONSOLE_H
+
+#include <stdint.h>
+
+/*
+ * Host-side USB CDC console bridge (-usb-console).
+ *
+ * TCP: listen on a port; one client at a time (nc localhost <port>).
+ * PTY:  virtual serial (screen/cu on symlink).
+ *
+ * RX: usb_console_poll() reads host bytes and pushes them into the guest
+ *     via usb_cdc_rx_push() (declared in usb.h).
+ * TX: usb.c calls usb_console_tx() from the CDC bulk IN handler.
+ */
+
+/* Configure before usb_console_init(). port > 0 enables TCP; 0 leaves off. */
+void usb_console_set_port(int port);
+
+/* Enable PTY transport; optional symlink (NULL or "" = no symlink). */
+void usb_console_set_pty(const char *symlink_path);
+
+int  usb_console_init(void);
+void usb_console_cleanup(void);
+
+int  usb_console_active(void);
+
+/* Accept clients, flush pending TX, read host input → usb_cdc_rx_push. */
+void usb_console_poll(void);
+
+/* Guest CDC IN payload → host TCP/PTY (buffers until client connects). */
+void usb_console_tx(const uint8_t *data, int len);
+
+/* ------------------------------------------------------------------ */
+/* Names used in the local Bramble tree (drop-in aliases).             */
+/* ------------------------------------------------------------------ */
+
+#define usb_console_tcp_set_port   usb_console_set_port
+#define usb_console_tcp_init       usb_console_init
+#define usb_console_tcp_cleanup    usb_console_cleanup
+#define usb_console_tcp_active     usb_console_active
+#define usb_console_tcp_poll       usb_console_poll
+#define usb_console_tcp_tx         usb_console_tx
+
+static inline void usb_console_tcp_poll_rx(int force_rx) {
+    (void)force_rx;
+    usb_console_poll();
+}
+
+#endif /* USB_CONSOLE_H */

--- a/src/corepool.c
+++ b/src/corepool.c
@@ -28,6 +28,15 @@
 #include "timer.h"
 #include "usb.h"
 
+/* macOS pthread_cond_timedwait uses CLOCK_REALTIME; no setclock API */
+#if defined(__APPLE__)
+#define COREPOOL_COND_CLOCK_ID CLOCK_REALTIME
+#define COREPOOL_COND_USE_SETCLOCK 0
+#else
+#define COREPOOL_COND_CLOCK_ID CLOCK_MONOTONIC
+#define COREPOOL_COND_USE_SETCLOCK 1
+#endif
+
 /*
  * Each host thread keeps the big lock for a short burst of guest work before
  * yielding. This cuts mutex/scheduler overhead without changing interrupt
@@ -71,7 +80,9 @@ void corepool_init(void) {
 
     pthread_condattr_t attr;
     pthread_condattr_init(&attr);
-    pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
+#if COREPOOL_COND_USE_SETCLOCK
+    pthread_condattr_setclock(&attr, COREPOOL_COND_CLOCK_ID);
+#endif
     pthread_cond_init(&corepool.wfi_cond, &attr);
     pthread_condattr_destroy(&attr);
 
@@ -287,7 +298,7 @@ static void *core_thread_fn(void *arg) {
             if (cores[core_id].is_halted) {
                 /* Halted core: sleep briefly then re-check (may be re-launched) */
                 struct timespec ts;
-                clock_gettime(CLOCK_MONOTONIC, &ts);
+                clock_gettime(COREPOOL_COND_CLOCK_ID, &ts);
                 ts.tv_nsec += 1000000;  /* 1ms */
                 if (ts.tv_nsec >= 1000000000) {
                     ts.tv_sec++;
@@ -317,7 +328,7 @@ static void *core_thread_fn(void *arg) {
                 struct timespec end;
 
                 clock_gettime(CLOCK_MONOTONIC, &start);
-                ts = start;
+                clock_gettime(COREPOOL_COND_CLOCK_ID, &ts);
                 ts.tv_nsec += 1000000;  /* 1ms */
                 if (ts.tv_nsec >= 1000000000) {
                     ts.tv_sec++;
@@ -336,11 +347,10 @@ static void *core_thread_fn(void *arg) {
                     systick_tick_for_core(core_id, (uint32_t)elapsed_cycles);
                 }
 
-                /* If every active core is sleeping/halted, use host elapsed time
-                 * as a fallback so timer-driven wakeups still happen. */
-                if (core_id == CORE0 &&
-                    (num_active_cores == 1 || cores[CORE1].is_wfi || cores[CORE1].is_halted) &&
-                    elapsed_us > 0) {
+                /* Any core in WFI/WFE: advance shared TIMER by host elapsed so
+                 * sleep_until/alarms work while the peer core stays busy (e.g.
+                 * cyw43_arch_init on core0 + BusLoop on core1). */
+                if (elapsed_us > 0) {
                     timer_tick(elapsed_us);
                     rtc_tick(elapsed_us);
                 }

--- a/src/main.c
+++ b/src/main.c
@@ -50,6 +50,7 @@ typedef enum { ARCH_M0PLUS, ARCH_RV32, ARCH_M33 } arch_t;
 #include "pio.h"
 #include "gdb.h"
 #include "usb.h"
+#include "usb_console.h"
 #include "rtc.h"
 #include "netbridge.h"
 #include "wire.h"
@@ -190,7 +191,7 @@ static void uart_stdin_cleanup(void) {
  * stdio. That keeps littleOS interactive while still allowing USB-only
  * shells such as MicroPython to consume stdin through CDC. */
 static stdin_target_t stdin_select_target(void) {
-    int usb_ready = usb_cdc_stdout_enabled && usb_cdc_stdio_active();
+    int usb_ready = usb_cdc_stdio_active();
     int uart_ready = stdin_uart0_rx_ready();
     int uart_console_ready = stdin_uart0_console_active();
 
@@ -198,7 +199,7 @@ static stdin_target_t stdin_select_target(void) {
         return STDIN_TARGET_UART0;
     }
 
-    if (usb_ready) {
+    if (usb_ready && (usb_cdc_stdout_enabled || usb_console_active())) {
         return STDIN_TARGET_USB_CDC;
     }
 
@@ -290,6 +291,9 @@ static void reset_runtime_peripherals(const char *tap_name) {
     clocks_init();
     adc_init();
     usb_init();
+    if (usb_console_init() < 0) {
+        fprintf(stderr, "[Error] Failed to initialize USB CDC console\n");
+    }
     rtc_init();
 
     if (cyw43.enabled) {
@@ -336,6 +340,9 @@ int main(int argc, char **argv) {
         fprintf(stderr, "  -asm       Show assembly instruction tracing\n");
         fprintf(stderr, "  -status    Print periodic status updates\n");
         fprintf(stderr, "  -stdin     Enable stdin polling for guest console input\n");
+        fprintf(stderr, "  -usb-console <port>  Bidirectional USB CDC over TCP (nc localhost <port>)\n");
+        fprintf(stderr, "  -usb-console pty[:path]  USB CDC on a PTY (default symlink /tmp/bramble-usb-console)\n");
+        fprintf(stderr, "  -usb-serial [path]     Alias for -usb-console pty[:path]\n");
         fprintf(stderr, "  -gdb [port] Start GDB server (default port: %d)\n", GDB_DEFAULT_PORT);
         fprintf(stderr, "  -clock <MHz> Set CPU clock frequency (default: 1, real: 125)\n");
         fprintf(stderr, "  -cores <N|auto> Active cores per instance (1, 2, or auto; default: 1)\n");
@@ -457,6 +464,22 @@ int main(int argc, char **argv) {
         } else if (strcmp(argv[i], "-stdin") == 0) {
             stdin_enabled = 1;
             usb_cdc_stdout_enabled = 1;
+        } else if (strcmp(argv[i], "-usb-serial") == 0) {
+            const char *link = "/tmp/bramble-usb-console";
+            if (i + 1 < argc && argv[i + 1][0] != '-')
+                link = argv[++i];
+            usb_console_set_pty(link);
+        } else if (strcmp(argv[i], "-usb-console") == 0) {
+            if (i + 1 < argc) {
+                const char *arg = argv[++i];
+                if (strcmp(arg, "pty") == 0)
+                    usb_console_set_pty("/tmp/bramble-usb-console");
+                else if (strncmp(arg, "pty:", 4) == 0) {
+                    const char *link = arg + 4;
+                    usb_console_set_pty(link[0] ? link : NULL);
+                } else
+                    usb_console_set_port(atoi(arg));
+            }
         } else if (strcmp(argv[i], "-gdb") == 0) {
             gdb_enabled = 1;
             if (i + 1 < argc && argv[i + 1][0] != '-') {
@@ -1551,6 +1574,7 @@ skip_fuse:
         mem_heatmap_cleanup();
     }
     if (script_enabled) script_cleanup();
+    usb_console_cleanup();
     if (symbols_loaded) symbols_cleanup();
 
     /* Determine exit code */

--- a/src/usb.c
+++ b/src/usb.c
@@ -16,6 +16,7 @@
 #include <string.h>
 #include <stdio.h>
 #include "usb.h"
+#include "usb_console.h"
 #include "nvic.h"
 #include "devtools.h"
 
@@ -404,6 +405,8 @@ static void usb_handle_cdc(void) {
             /* Output CDC data to stdout only when USB CDC stdio is primary
              * (i.e. -stdin mode). When UART stdio is also active, UART
              * already handles stdout and we must not duplicate the data. */
+            if (usb_console_active())
+                usb_console_tx(&usb_state.dpram[buf_addr], len);
             if (usb_cdc_stdout_enabled) {
                 fwrite(&usb_state.dpram[buf_addr], 1, len, stdout);
                 fflush(stdout);
@@ -485,6 +488,9 @@ static void usb_cdc_rx_drain(void) {
  * ======================================================================== */
 
 void usb_step(void) {
+    if (usb_console_active())
+        usb_console_poll();
+
     /* Only active when controller is enabled */
     if (!(usb_state.main_ctrl & USB_MAIN_CTRL_EN)) {
         return;

--- a/src/usb_console.c
+++ b/src/usb_console.c
@@ -1,0 +1,357 @@
+/*
+ * USB CDC host console bridge (TCP / PTY).
+ *
+ * Standalone translation unit for upstream Bramble: no MegaFlash guest
+ * stubs, no XMODEM, no SPI. Depends only on usb.h for usb_cdc_rx_push().
+ */
+
+#include "usb_console.h"
+#include "usb.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <poll.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#if !defined(_WIN32)
+#include <termios.h>
+#include <util.h>
+#endif
+
+typedef enum {
+    USB_CONSOLE_OFF = 0,
+    USB_CONSOLE_TCP,
+    USB_CONSOLE_PTY,
+} usb_console_transport_t;
+
+typedef struct {
+    usb_console_transport_t transport;
+    int listen_fd;
+    int client_fd;
+    int port;
+    char pty_slave_name[128];
+    char pty_symlink[256];
+} usb_console_bridge_t;
+
+#define USB_CONSOLE_TX_PENDING_MAX 4096u
+
+static usb_console_bridge_t usb_console;
+static uint8_t usb_console_tx_pending[USB_CONSOLE_TX_PENDING_MAX];
+static size_t usb_console_tx_pending_len;
+
+static void usb_console_set_nonblock(int fd) {
+    int flags = fcntl(fd, F_GETFL, 0);
+    if (flags != -1) {
+        fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+    }
+}
+
+static void usb_console_set_nodelay(int fd) {
+    int flag = 1;
+    setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag));
+}
+
+static void usb_console_tx_flush_pending(void) {
+    if (usb_console.client_fd < 0 || usb_console_tx_pending_len == 0u) {
+        return;
+    }
+
+    size_t off = 0;
+    while (off < usb_console_tx_pending_len) {
+        ssize_t n = write(usb_console.client_fd,
+                          usb_console_tx_pending + off,
+                          usb_console_tx_pending_len - off);
+        if (n > 0) {
+            off += (size_t)n;
+            continue;
+        }
+        if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+            break;
+        }
+        if (usb_console.transport == USB_CONSOLE_PTY) {
+            break;
+        }
+        close(usb_console.client_fd);
+        usb_console.client_fd = -1;
+        usb_console_tx_pending_len = 0;
+        return;
+    }
+
+    if (off > 0u) {
+        memmove(usb_console_tx_pending,
+                usb_console_tx_pending + off,
+                usb_console_tx_pending_len - off);
+        usb_console_tx_pending_len -= off;
+    }
+}
+
+void usb_console_set_port(int port) {
+    usb_console.port = port;
+    usb_console.transport = port > 0 ? USB_CONSOLE_TCP : USB_CONSOLE_OFF;
+}
+
+void usb_console_set_pty(const char *symlink_path) {
+    usb_console.transport = USB_CONSOLE_PTY;
+    usb_console.port = 0;
+    usb_console.pty_symlink[0] = '\0';
+    if (symlink_path != NULL && symlink_path[0] != '\0') {
+        strncpy(usb_console.pty_symlink, symlink_path,
+                sizeof(usb_console.pty_symlink) - 1u);
+        usb_console.pty_symlink[sizeof(usb_console.pty_symlink) - 1u] = '\0';
+    }
+}
+
+int usb_console_active(void) {
+    return usb_console.transport != USB_CONSOLE_OFF;
+}
+
+#if !defined(_WIN32)
+static int usb_console_pty_init(void) {
+    int master = -1;
+    int slave = -1;
+    char slave_name[sizeof(usb_console.pty_slave_name)];
+
+    if (openpty(&master, &slave, slave_name, NULL, NULL) != 0) {
+        fprintf(stderr, "[USB] PTY console: openpty failed: %s\n", strerror(errno));
+        return -1;
+    }
+#if defined(__linux__)
+    if (grantpt(slave) != 0 || unlockpt(slave) != 0) {
+        fprintf(stderr, "[USB] PTY console: grant/unlock failed: %s\n",
+                strerror(errno));
+        close(master);
+        close(slave);
+        return -1;
+    }
+#endif
+
+    usb_console_set_nonblock(master);
+    struct termios tio;
+    if (tcgetattr(master, &tio) == 0) {
+        cfmakeraw(&tio);
+        tio.c_cflag |= (tcflag_t)(CLOCAL | CREAD);
+        (void)tcsetattr(master, TCSANOW, &tio);
+    }
+
+    usb_console.client_fd = master;
+    strncpy(usb_console.pty_slave_name, slave_name,
+            sizeof(usb_console.pty_slave_name) - 1u);
+    usb_console.pty_slave_name[sizeof(usb_console.pty_slave_name) - 1u] = '\0';
+
+    const char *open_path = usb_console.pty_slave_name;
+    if (usb_console.pty_symlink[0] != '\0') {
+        unlink(usb_console.pty_symlink);
+        if (symlink(usb_console.pty_slave_name, usb_console.pty_symlink) != 0) {
+            fprintf(stderr, "[USB] PTY console: symlink %s -> %s failed: %s\n",
+                    usb_console.pty_symlink, usb_console.pty_slave_name,
+                    strerror(errno));
+        } else {
+            open_path = usb_console.pty_symlink;
+            fprintf(stderr, "[USB] CDC console symlink: %s -> %s\n",
+                    usb_console.pty_symlink, usb_console.pty_slave_name);
+        }
+    }
+
+    fprintf(stderr,
+            "[USB] CDC console on serial port %s\n"
+            "[USB]   attach: screen %s 115200   (or cu -l %s -s 115200)\n",
+            usb_console.pty_slave_name, open_path, open_path);
+
+    /* Do not keep slave open — macOS clients cannot read it otherwise. */
+    close(slave);
+
+    if (usb_console_tx_pending_len > 0u) {
+        usb_console_tx(usb_console_tx_pending,
+                       (int)usb_console_tx_pending_len);
+        usb_console_tx_pending_len = 0;
+    }
+    return 0;
+}
+#endif /* !_WIN32 */
+
+int usb_console_init(void) {
+    usb_console.listen_fd = -1;
+    usb_console.client_fd = -1;
+    usb_console.pty_slave_name[0] = '\0';
+    usb_console_tx_pending_len = 0;
+
+    if (usb_console.transport == USB_CONSOLE_OFF) {
+        return 0;
+    }
+
+#if !defined(_WIN32)
+    if (usb_console.transport == USB_CONSOLE_PTY) {
+        return usb_console_pty_init();
+    }
+#endif
+
+    if (usb_console.transport != USB_CONSOLE_TCP) {
+        fprintf(stderr, "[USB] PTY console is not supported on this platform\n");
+        return -1;
+    }
+
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        fprintf(stderr, "[USB] TCP console: socket failed: %s\n", strerror(errno));
+        return -1;
+    }
+
+    int opt = 1;
+    setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = INADDR_ANY;
+    addr.sin_port = htons((uint16_t)usb_console.port);
+
+    if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0 ||
+        listen(fd, 1) < 0) {
+        fprintf(stderr, "[USB] TCP console: listen on %d failed: %s\n",
+                usb_console.port, strerror(errno));
+        close(fd);
+        return -1;
+    }
+
+    usb_console_set_nonblock(fd);
+    usb_console.listen_fd = fd;
+    fprintf(stderr,
+            "[USB] CDC console listening on TCP port %d (nc localhost %d)\n",
+            usb_console.port, usb_console.port);
+    return 0;
+}
+
+void usb_console_cleanup(void) {
+    if (usb_console.client_fd >= 0) {
+        close(usb_console.client_fd);
+        usb_console.client_fd = -1;
+    }
+    if (usb_console.listen_fd >= 0) {
+        close(usb_console.listen_fd);
+        usb_console.listen_fd = -1;
+    }
+    if (usb_console.pty_symlink[0] != '\0') {
+        unlink(usb_console.pty_symlink);
+    }
+    usb_console.transport = USB_CONSOLE_OFF;
+    usb_console_tx_pending_len = 0;
+}
+
+void usb_console_tx(const uint8_t *data, int len) {
+    if (len <= 0) {
+        return;
+    }
+
+    if (usb_console.client_fd < 0) {
+        for (int i = 0; i < len; i++) {
+            if (usb_console_tx_pending_len < USB_CONSOLE_TX_PENDING_MAX) {
+                usb_console_tx_pending[usb_console_tx_pending_len++] = data[i];
+            }
+        }
+        return;
+    }
+
+    if (usb_console_tx_pending_len > 0u) {
+        usb_console_tx_flush_pending();
+    }
+
+    ssize_t off = 0;
+    while (off < len) {
+        ssize_t n = write(usb_console.client_fd, data + off, (size_t)(len - off));
+        if (n > 0) {
+            off += n;
+            continue;
+        }
+        if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+            for (ssize_t i = off; i < len; i++) {
+                if (usb_console_tx_pending_len < USB_CONSOLE_TX_PENDING_MAX) {
+                    usb_console_tx_pending[usb_console_tx_pending_len++] =
+                        data[(size_t)i];
+                }
+            }
+            break;
+        }
+        if (usb_console.transport == USB_CONSOLE_PTY) {
+            for (ssize_t i = off; i < len; i++) {
+                if (usb_console_tx_pending_len < USB_CONSOLE_TX_PENDING_MAX) {
+                    usb_console_tx_pending[usb_console_tx_pending_len++] =
+                        data[(size_t)i];
+                }
+            }
+            break;
+        }
+        fprintf(stderr, "[USB] CDC console write error, disconnecting\n");
+        close(usb_console.client_fd);
+        usb_console.client_fd = -1;
+        break;
+    }
+}
+
+void usb_console_poll(void) {
+    if (usb_console.transport == USB_CONSOLE_OFF) {
+        return;
+    }
+
+    usb_console_tx_flush_pending();
+
+    if (usb_console.transport == USB_CONSOLE_TCP &&
+        usb_console.listen_fd >= 0 && usb_console.client_fd < 0) {
+        struct sockaddr_in client_addr;
+        socklen_t addr_len = sizeof(client_addr);
+        int cfd = accept(usb_console.listen_fd,
+                         (struct sockaddr *)&client_addr, &addr_len);
+        if (cfd >= 0) {
+            usb_console_set_nonblock(cfd);
+            usb_console_set_nodelay(cfd);
+            usb_console.client_fd = cfd;
+            fprintf(stderr, "[USB] CDC console client connected from %s:%d\n",
+                    inet_ntoa(client_addr.sin_addr),
+                    ntohs(client_addr.sin_port));
+            if (usb_console_tx_pending_len > 0u) {
+                usb_console_tx(usb_console_tx_pending,
+                               (int)usb_console_tx_pending_len);
+                usb_console_tx_pending_len = 0;
+            }
+        }
+    }
+
+    if (usb_console.client_fd < 0) {
+        return;
+    }
+
+    struct pollfd pfd = { .fd = usb_console.client_fd, .events = POLLIN };
+    if (poll(&pfd, 1, 0) <= 0 || !(pfd.revents & POLLIN)) {
+        return;
+    }
+
+    uint8_t buf[4096];
+    for (;;) {
+        ssize_t n = read(usb_console.client_fd, buf, sizeof(buf));
+        if (n > 0) {
+            for (ssize_t j = 0; j < n; j++) {
+                if (!usb_cdc_rx_push(buf[j])) {
+                    return;
+                }
+            }
+            continue;
+        }
+        if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+            break;
+        }
+        if (n == 0) {
+            if (usb_console.transport == USB_CONSOLE_PTY) {
+                return;
+            }
+            fprintf(stderr, "[USB] CDC console client disconnected\n");
+            close(usb_console.client_fd);
+            usb_console.client_fd = -1;
+        }
+        break;
+    }
+}


### PR DESCRIPTION
## Summary
- Standalone `usb_console.c` hooked into upstream CDC IN/OUT
- CLI: `-usb-console <port|pty[:path]>`, `-usb-serial`
- Docs: `docs/USB-CONSOLE.md`

**Excluded:** MegaFlash UserTerminal, XMODEM, SPI flash, `usb_guest.h`.

## Test plan
- [ ] `make -C build bramble bramble_tests && ./build/bramble_tests`
- [ ] `./bramble fw.uf2 -usb-console 9999` then `nc localhost 9999` after CDC enum
- [ ] `./bramble fw.uf2 -usb-console pty` then `screen /tmp/bramble-usb-console`