### PR TITLE
feat(core): Thumb/M33, dual-core, DMA/PIO/NVIC, weak ext stubs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ set(EMU_SOURCES
     src/cyw43.c
     src/tapif.c
     src/devtools.c
+    src/bramble_ext_stubs.c
     src/vnet.c
     src/sdd.c
     src/sdd_thermo.c

--- a/docs/UPSTREAM-CORE.md
+++ b/docs/UPSTREAM-CORE.md
@@ -1,0 +1,17 @@
+# Core emulator improvements (eositis → Night-Traders)
+
+This PR packages RP2350/M33 and host-runtime fixes that are independent of
+Apple/MegaFlash/a2bus:
+
+- Thumb-2 / instruction decode improvements (`thumb32`, `instructions`)
+- Dual-core / WFI host threading (`corepool`)
+- DMA BSWAP / NVIC / PIO bounds and inject helpers
+- UART / netbridge console polish
+- Weak empty `bramble_ext_*` stubs for optional out-of-tree overlays
+- SPI peripheral idle/MISO fidelity (`spi.c`)
+
+**Not included here:** CYW43/TAP (separate radio PR), `-spi-flash*` host files
+(separate SPI PR), `-usb-console` (separate USB PR), MegaFlash guest stubs.
+
+**Note:** `src/thumb32.c` also diverged on upstream v0.46 (unknown-op no-ops).
+Please reconcile with that change when merging.

--- a/include/bramble_ext.h
+++ b/include/bramble_ext.h
@@ -1,0 +1,37 @@
+#ifndef BRAMBLE_EXT_H
+#define BRAMBLE_EXT_H
+
+/*
+ * Optional in-process extension hooks (weak stubs in stock Bramble).
+ * megaflash-vm overlay provides strong definitions for Apple-bus / MegaFlash.
+ */
+
+/* Return 1 if argv[*argi] was consumed (may advance *argi). */
+int bramble_ext_parse_arg(int *argi, int argc, char **argv);
+
+/* After symbols/UF2 load — start bridges, resolve BSS, etc. */
+void bramble_ext_post_init(const char *symbols_path);
+
+/* Nonzero while an interactive extension session should disable safety exits. */
+int bramble_ext_active(void);
+
+void bramble_ext_poll(void);
+void bramble_ext_cleanup(void);
+
+/* Per-guest-instruction hook. Return 1 if PC was handled. */
+int bramble_ext_guest_hook(void);
+
+/*
+ * Script extensions: parse returns 1 and fills type (>= 100 for ext types).
+ * run returns 1 if type was handled.
+ */
+int bramble_ext_script_parse(const char *cmd, const char *arg,
+                             int *type, int *channel, int *gpio_val);
+int bramble_ext_script_run(int type, int channel, int gpio_val);
+
+/* Wall-clock script timing while extension active (MAME sessions). */
+int bramble_ext_script_use_wallclock(void);
+
+void bramble_ext_print_help(void);
+
+#endif /* BRAMBLE_EXT_H */

--- a/include/corepool.h
+++ b/include/corepool.h
@@ -3,6 +3,7 @@
 
 #include <pthread.h>
 #include <stdint.h>
+#include <unistd.h>
 
 /* ========================================================================
  * Core Pool — Host-Threaded Execution & Multi-Instance Coordination

--- a/include/dma.h
+++ b/include/dma.h
@@ -1,7 +1,7 @@
 /*
- * RP2040 DMA Controller Emulation
+ * RP2040 / RP2350 DMA Controller Emulation
  *
- * 12 independent DMA channels with:
+ * Up to 16 DMA channels (12 on RP2040, 16 on RP2350) with:
  * - READ_ADDR, WRITE_ADDR, TRANS_COUNT, CTRL_TRIG per channel
  * - 4 alias register blocks per channel (AL1-AL3 reorder fields)
  * - Immediate (synchronous) transfer on trigger
@@ -10,6 +10,10 @@
  * - CHAIN_TO for channel chaining
  * - Global interrupt registers (INTR, INTE0/1, INTF0/1, INTS0/1)
  * - Atomic register aliases (SET/CLR/XOR)
+ *
+ * CTRL_TRIG bit positions and some global register offsets differ between
+ * RP2040 and RP2350. Macros below are the RP2040 layout (used by unit tests);
+ * dma.c selects the active layout from membus_rp2350_mode at runtime.
  */
 
 #ifndef DMA_H
@@ -22,9 +26,11 @@
  * ======================================================================== */
 
 #define DMA_BASE            0x50000000
-#define DMA_NUM_CHANNELS    12
+#define DMA_NUM_CHANNELS_RP2040  12
+#define DMA_NUM_CHANNELS_RP2350  16
+#define DMA_NUM_CHANNELS    DMA_NUM_CHANNELS_RP2350  /* storage covers both */
 #define DMA_CH_STRIDE       0x40    /* 64 bytes per channel */
-#define DMA_BLOCK_SIZE      0x4C0   /* channels (0x300) + global regs */
+#define DMA_BLOCK_SIZE      0x500   /* channels (0x400) + RP2350 global regs */
 
 /* ========================================================================
  * Per-Channel Register Offsets (within 0x40-byte channel block)
@@ -55,7 +61,7 @@
 #define DMA_CH_AL3_READ_ADDR_TRIG   0x3C
 
 /* ========================================================================
- * CTRL_TRIG Bitfields
+ * CTRL_TRIG Bitfields — RP2040 layout (unit tests / default macros)
  * ======================================================================== */
 
 #define DMA_CTRL_EN             (1 << 0)
@@ -79,6 +85,15 @@
 #define DMA_CTRL_READ_ERROR     (1 << 30)   /* W1C */
 #define DMA_CTRL_AHB_ERROR      (1 << 31)   /* read-only */
 
+/* RP2350 CTRL_TRIG differences (BUSY/BSWAP/CHAIN_TO/INCR_WRITE shifted) */
+#define DMA_CTRL_INCR_WRITE_RP2350     (1u << 6)
+#define DMA_CTRL_CHAIN_TO_MASK_RP2350  (0xFu << 13)
+#define DMA_CTRL_CHAIN_TO_SHIFT_RP2350 13
+#define DMA_CTRL_IRQ_QUIET_RP2350      (1u << 23)
+#define DMA_CTRL_BSWAP_RP2350          (1u << 24)
+#define DMA_CTRL_SNIFF_EN_RP2350       (1u << 25)
+#define DMA_CTRL_BUSY_RP2350           (1u << 26)
+
 /* DATA_SIZE values */
 #define DMA_SIZE_BYTE           0
 #define DMA_SIZE_HALFWORD       1
@@ -100,12 +115,20 @@
 #define DMA_TIMER1              0x424
 #define DMA_TIMER2              0x428
 #define DMA_TIMER3              0x42C
+/* RP2040 globals */
 #define DMA_MULTI_CHAN_TRIGGER  0x430
 #define DMA_SNIFF_CTRL          0x434
 #define DMA_SNIFF_DATA          0x438
 #define DMA_FIFO_LEVELS         0x440
 #define DMA_CHAN_ABORT           0x444
 #define DMA_N_CHANNELS          0x448
+/* RP2350 globals (shifted after extra timer/MPU regs) */
+#define DMA_MULTI_CHAN_TRIGGER_RP2350  0x450
+#define DMA_SNIFF_CTRL_RP2350          0x454
+#define DMA_SNIFF_DATA_RP2350          0x458
+#define DMA_FIFO_LEVELS_RP2350         0x460
+#define DMA_CHAN_ABORT_RP2350           0x464
+#define DMA_N_CHANNELS_RP2350          0x468
 
 /* ========================================================================
  * Per-Channel State

--- a/include/emulator.h
+++ b/include/emulator.h
@@ -82,6 +82,8 @@ uint32_t timing_instruction_cycles_32(uint16_t upper, uint16_t lower);
 
 /* SIO (Single-cycle I/O) - RP2040 core registers */
 #define SIO_BASE        0xD0000000
+/* RP2350 non-secure SIO view (same register layout, +0x20000 from secure) */
+#define SIO_NONSEC_BASE 0xD0020000
 
 /* Peripherals - see individual headers (uart.h, spi.h, i2c.h, pwm.h) */
 
@@ -180,6 +182,10 @@ typedef struct {
     int core_id;                    /* 0 or 1 */
     int is_halted;                  /* Execution state */
     int is_wfi;                     /* Core sleeping (WFI/WFE), skip until interrupt */
+    uint8_t it_remaining;           /* Thumb IT block: instructions left to predicate */
+    uint8_t it_cond;                /* IT block base condition (bits [7:4] of IT insn) */
+    uint8_t it_mask;                /* IT block mask (bits [3:0] of IT insn) */
+    uint8_t it_total;               /* IT block length (for mask bit indexing) */
     uint32_t exception_sp;          /* Saved SP for exception handling */
     int in_handler_mode;            /* True if currently in ISR */
 
@@ -215,6 +221,12 @@ extern multicore_fifo_t fifo[NUM_CORES];
 /* Set active RAM pointer for memory bus routing (eliminates per-step memcpy) */
 void mem_set_ram_ptr(uint8_t *ram, uint32_t base, uint32_t size);
 
+/* Bulk RAM fill (returns 1 if dest/len are in active RAM) */
+int mem_guest_memset(uint32_t dest, int val, uint32_t len);
+int mem_guest_memset_words(uint32_t dest, uint32_t word, uint32_t len);
+int mem_guest_memcpy(uint32_t dest, uint32_t src_flash, uint32_t len);
+int mem_guest_memcpy_any(uint32_t dest, uint32_t src, uint32_t len);
+
 /* pc_updated flag: set by instruction handlers that modify PC */
 extern int pc_updated;
 
@@ -239,6 +251,10 @@ void mem_write16(uint32_t addr, uint16_t val);
 uint16_t mem_read16(uint32_t addr);
 
 void mem_write8(uint32_t addr, uint8_t val);
+
+/* Set alarm-pool wake byte (+8) for one validated node in SRAM. */
+void membus_alarm_pool_wake_node(uint32_t node_addr);
+void membus_alarm_pool_wake_pending(void);
 uint8_t mem_read8(uint32_t addr);
 
 /* ========================================================================
@@ -334,6 +350,11 @@ uint32_t sio_get_core_id(void);
 void sio_set_core1_reset(int assert_reset);
 void sio_set_core1_stall(int stall);
 int sio_core1_bootrom_handle_fifo_write(uint32_t val);
+void sio_force_core1_launch(uint32_t entry_pc, uint32_t stack_sp, uint32_t vtor);
+
+/* Set to 1 to log Core 1 launch / SIO FIFO / PSM activity (-trace-mc) */
+extern int multicore_trace_enabled;
+extern uint32_t sio_fifo_wr_total;
 
 /* Boot2 detection */
 int cpu_has_boot2(void);

--- a/include/instructions.h
+++ b/include/instructions.h
@@ -124,7 +124,9 @@ void instr_mov_high_reg(uint16_t instr);           // MOV Rd, Rm (high registers
 // ============================================================================
 
 // Conditional Execution
-void instr_it(uint16_t instr);                     // IT{x{y{z}}} cond
+void instr_it(uint16_t instr);
+/* Returns 1 if the instruction at PC should execute, 0 to skip (IT predicate false). */
+int thumb_it_should_execute(int core_id);                     // IT{x{y{z}}} cond
 
 // Memory Barriers (32-bit instructions)
 void instr_dsb(uint32_t instr);                    // DSB (data sync barrier)

--- a/include/netbridge.h
+++ b/include/netbridge.h
@@ -11,10 +11,9 @@
  * (client) modes for each UART.
  *
  * Usage:
- *   -net-uart0 <port>         Listen on TCP port for UART0
- *   -net-uart1 <port>         Listen on TCP port for UART1
- *   -net-uart0-connect <host:port>  Connect UART0 to remote
- *   -net-uart1-connect <host:port>  Connect UART1 to remote
+ *   -uart-console <port>     Listen on TCP (UART0); connect with nc/socat
+ *   -net-uart0 <port>         Same as -uart-console
+ *   -net-uart0-connect <host:port>  TCP client mode
  * ======================================================================== */
 
 #define NET_BRIDGE_MAX_UART  2
@@ -57,5 +56,11 @@ void net_bridge_uart_tx(int uart_num, uint8_t byte);
 
 /* Returns 1 if UART has a network bridge active */
 int  net_bridge_uart_active(int uart_num);
+
+/* Returns 1 if any UART has a TCP bridge configured */
+int net_bridge_any_active(void);
+
+/* When set, guest UART TX is also copied to host stderr */
+extern int net_bridge_mirror_stdio;
 
 #endif /* NETBRIDGE_H */

--- a/include/nvic.h
+++ b/include/nvic.h
@@ -71,11 +71,21 @@
 #define IRQ_ADC_IRQ_FIFO            22     /* ADC_IRQ_FIFO */
 #define IRQ_I2C0_IRQ                23     /* I2C0_IRQ */
 #define IRQ_I2C1_IRQ                24     /* I2C1_IRQ */
-#define IRQ_RTC_IRQ                 25     /* RTC_IRQ */
+#define IRQ_RTC_IRQ                 25     /* RTC_IRQ (RP2040) */
 
-#define NUM_EXTERNAL_IRQS           26     /* RP2040 has 26 external IRQs */
+#define NUM_EXTERNAL_IRQS           26     /* RP2040 external IRQ count */
+#define NUM_EXTERNAL_IRQS_RP2350      52     /* RP2350 external IRQ count */
+#define NUM_EXTERNAL_IRQS_MAX         NUM_EXTERNAL_IRQS_RP2350
+
 #define NUM_EXCEPTIONS              16     /* System exceptions (0-15) */
-#define NUM_TOTAL_IRQS              (NUM_EXCEPTIONS + NUM_EXTERNAL_IRQS)  /* 42 total */
+#define NUM_TOTAL_IRQS              (NUM_EXCEPTIONS + NUM_EXTERNAL_IRQS_MAX)
+
+/* Active external IRQ count (26 on RP2040, 52 on RP2350) */
+uint32_t nvic_num_external_irqs(void);
+
+static inline int nvic_irq_valid(uint32_t irq) {
+    return irq < nvic_num_external_irqs();
+}
 
 /* Priority levels (Cortex-M0+ supports 4 levels, using bits 6-7 of IPR) */
 #define IRQ_PRIORITY_0              0      /* Highest priority */
@@ -103,11 +113,11 @@ typedef struct {
 
 /* NVIC State Structure */
 typedef struct {
-    uint32_t enable;                /* ISER - Interrupt enable bits */
-    uint32_t pending;               /* ISPR - Pending interrupt bits */
-    uint8_t priority[NUM_EXTERNAL_IRQS];  /* IPR - Priority for each IRQ */
+    uint64_t enable;                /* ISER - Interrupt enable bits (IRQ 0-51 on RP2350) */
+    uint64_t pending;               /* ISPR - Pending interrupt bits */
+    uint8_t priority[NUM_EXTERNAL_IRQS_MAX];  /* IPR - Priority for each IRQ */
     uint32_t active_exceptions;     /* Bitmask of currently executing exceptions */
-    uint32_t iabr;                  /* IABR - Active Bit Register */
+    uint64_t iabr;                  /* IABR - Active Bit Register */
     uint32_t shpr2;                 /* System Handler Priority 2 (SVCall) */
     uint32_t shpr3;                 /* System Handler Priority 3 (PendSV, SysTick) */
     int pendsv_pending;             /* PendSV exception pending */

--- a/include/pio.h
+++ b/include/pio.h
@@ -187,6 +187,10 @@ void     pio_write32(int pio_num, uint32_t offset, uint32_t val);
 /* Step all enabled state machines in all PIO blocks (call from main loop) */
 void     pio_step(void);
 
+/* Push a word into an SM RX FIFO (Apple-bus stub / listener simulation) */
+void     pio_inject_rx(int pio_num, int sm_num, uint32_t word);
+void     pio_drain_rx(int pio_num, int sm_num);
+
 /* Execute one PIO instruction on a specific SM */
 void     pio_sm_exec(int pio_num, int sm_num, uint16_t instr);
 

--- a/include/thumb32.h
+++ b/include/thumb32.h
@@ -16,4 +16,7 @@
  */
 int thumb32_step(uint32_t pc, uint16_t upper, uint16_t lower);
 
+/* Clear local exclusive monitor after any store (ARM STREX semantics). */
+void thumb32_exclusive_monitor_clear(uint32_t addr);
+
 #endif /* THUMB32_H */

--- a/src/bramble_ext_stubs.c
+++ b/src/bramble_ext_stubs.c
@@ -1,0 +1,63 @@
+#include "bramble_ext.h"
+
+__attribute__((weak)) int bramble_ext_parse_arg(int *argi, int argc, char **argv)
+{
+    (void)argi;
+    (void)argc;
+    (void)argv;
+    return 0;
+}
+
+__attribute__((weak)) void bramble_ext_post_init(const char *symbols_path)
+{
+    (void)symbols_path;
+}
+
+__attribute__((weak)) int bramble_ext_active(void)
+{
+    return 0;
+}
+
+__attribute__((weak)) void bramble_ext_poll(void)
+{
+}
+
+__attribute__((weak)) void bramble_ext_cleanup(void)
+{
+}
+
+__attribute__((weak)) int bramble_ext_guest_hook(void)
+{
+    return 0;
+}
+
+__attribute__((weak)) int bramble_ext_script_parse(const char *cmd, const char *arg,
+                                                   int *type, int *channel, int *gpio_val)
+{
+    (void)cmd;
+    (void)arg;
+    (void)type;
+    (void)channel;
+    (void)gpio_val;
+    return 0;
+}
+
+__attribute__((weak)) int bramble_ext_script_run(int type, int channel, int gpio_val)
+{
+    (void)type;
+    (void)channel;
+    (void)gpio_val;
+    return 0;
+}
+
+__attribute__((weak)) int bramble_ext_script_use_wallclock(void)
+{
+    return 0;
+}
+
+__attribute__((weak)) void bramble_ext_print_help(void)
+{
+}
+
+/* Defined here so instructions.c WFI/WFE tracing links without full cpu.c fork. */
+int multicore_trace_enabled = 0;

--- a/src/corepool.c
+++ b/src/corepool.c
@@ -28,6 +28,15 @@
 #include "timer.h"
 #include "usb.h"
 
+/* macOS pthread_cond_timedwait uses CLOCK_REALTIME; no setclock API */
+#if defined(__APPLE__)
+#define COREPOOL_COND_CLOCK_ID CLOCK_REALTIME
+#define COREPOOL_COND_USE_SETCLOCK 0
+#else
+#define COREPOOL_COND_CLOCK_ID CLOCK_MONOTONIC
+#define COREPOOL_COND_USE_SETCLOCK 1
+#endif
+
 /*
  * Each host thread keeps the big lock for a short burst of guest work before
  * yielding. This cuts mutex/scheduler overhead without changing interrupt
@@ -71,7 +80,9 @@ void corepool_init(void) {
 
     pthread_condattr_t attr;
     pthread_condattr_init(&attr);
-    pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
+#if COREPOOL_COND_USE_SETCLOCK
+    pthread_condattr_setclock(&attr, COREPOOL_COND_CLOCK_ID);
+#endif
     pthread_cond_init(&corepool.wfi_cond, &attr);
     pthread_condattr_destroy(&attr);
 
@@ -287,7 +298,7 @@ static void *core_thread_fn(void *arg) {
             if (cores[core_id].is_halted) {
                 /* Halted core: sleep briefly then re-check (may be re-launched) */
                 struct timespec ts;
-                clock_gettime(CLOCK_MONOTONIC, &ts);
+                clock_gettime(COREPOOL_COND_CLOCK_ID, &ts);
                 ts.tv_nsec += 1000000;  /* 1ms */
                 if (ts.tv_nsec >= 1000000000) {
                     ts.tv_sec++;
@@ -317,7 +328,7 @@ static void *core_thread_fn(void *arg) {
                 struct timespec end;
 
                 clock_gettime(CLOCK_MONOTONIC, &start);
-                ts = start;
+                clock_gettime(COREPOOL_COND_CLOCK_ID, &ts);
                 ts.tv_nsec += 1000000;  /* 1ms */
                 if (ts.tv_nsec >= 1000000000) {
                     ts.tv_sec++;
@@ -336,11 +347,10 @@ static void *core_thread_fn(void *arg) {
                     systick_tick_for_core(core_id, (uint32_t)elapsed_cycles);
                 }
 
-                /* If every active core is sleeping/halted, use host elapsed time
-                 * as a fallback so timer-driven wakeups still happen. */
-                if (core_id == CORE0 &&
-                    (num_active_cores == 1 || cores[CORE1].is_wfi || cores[CORE1].is_halted) &&
-                    elapsed_us > 0) {
+                /* Any core in WFI/WFE: advance shared TIMER by host elapsed so
+                 * sleep_until/alarms work while the peer core stays busy (e.g.
+                 * cyw43_arch_init on core0 + BusLoop on core1). */
+                if (elapsed_us > 0) {
                     timer_tick(elapsed_us);
                     rtc_tick(elapsed_us);
                 }

--- a/src/dma.c
+++ b/src/dma.c
@@ -1,18 +1,14 @@
 /*
- * RP2040 DMA Controller Emulation
+ * RP2040 / RP2350 DMA Controller Emulation
  *
- * Implements 12 DMA channels with immediate (synchronous) transfers.
+ * Implements DMA channels with immediate (synchronous) transfers.
  * When a channel is triggered (CTRL_TRIG written with EN=1, or via alias
  * trigger registers), the transfer executes immediately within the write call.
  *
- * Supports:
- * - READ_ADDR / WRITE_ADDR with optional increment
- * - DATA_SIZE: byte, halfword, word
- * - TRANS_COUNT transfers per trigger
- * - CHAIN_TO: automatically triggers another channel on completion
- * - IRQ_QUIET: suppress interrupt on completion
- * - Global INTR/INTE/INTF/INTS interrupt registers
- * - All 4 alias register layouts per channel
+ * RP2350 differences vs RP2040 (selected via membus_rp2350_mode):
+ * - 16 channels (vs 12)
+ * - CTRL_TRIG: INCR_WRITE, CHAIN_TO, BSWAP, IRQ_QUIET, BUSY bit positions
+ * - Global regs MULTI_CHAN_TRIGGER / CHAN_ABORT / N_CHANNELS offsets
  */
 
 #include <string.h>
@@ -22,6 +18,39 @@
 
 dma_state_t dma_state;
 
+static int dma_n_channels(void) {
+    return membus_rp2350_mode ? DMA_NUM_CHANNELS_RP2350 : DMA_NUM_CHANNELS_RP2040;
+}
+
+static uint32_t dma_ctrl_incr_write_bit(void) {
+    return membus_rp2350_mode ? DMA_CTRL_INCR_WRITE_RP2350 : DMA_CTRL_INCR_WRITE;
+}
+
+static uint32_t dma_ctrl_bswap_bit(void) {
+    return membus_rp2350_mode ? DMA_CTRL_BSWAP_RP2350 : DMA_CTRL_BSWAP;
+}
+
+static uint32_t dma_ctrl_irq_quiet_bit(void) {
+    return membus_rp2350_mode ? DMA_CTRL_IRQ_QUIET_RP2350 : DMA_CTRL_IRQ_QUIET;
+}
+
+static uint32_t dma_ctrl_busy_bit(void) {
+    return membus_rp2350_mode ? DMA_CTRL_BUSY_RP2350 : DMA_CTRL_BUSY;
+}
+
+static uint32_t dma_ctrl_chain_to_mask(void) {
+    return membus_rp2350_mode ? DMA_CTRL_CHAIN_TO_MASK_RP2350 : DMA_CTRL_CHAIN_TO_MASK;
+}
+
+static int dma_ctrl_chain_to_shift(void) {
+    return membus_rp2350_mode ? DMA_CTRL_CHAIN_TO_SHIFT_RP2350 : DMA_CTRL_CHAIN_TO_SHIFT;
+}
+
+static uint32_t dma_ctrl_ro_mask(void) {
+    return dma_ctrl_busy_bit() | DMA_CTRL_AHB_ERROR |
+           DMA_CTRL_WRITE_ERROR | DMA_CTRL_READ_ERROR;
+}
+
 /* ========================================================================
  * Initialization
  * ======================================================================== */
@@ -29,8 +58,9 @@ dma_state_t dma_state;
 void dma_init(void) {
     memset(&dma_state, 0, sizeof(dma_state));
     /* Default CHAIN_TO = self (no chaining) for each channel */
+    int shift = dma_ctrl_chain_to_shift();
     for (int i = 0; i < DMA_NUM_CHANNELS; i++) {
-        dma_state.ch[i].ctrl = (uint32_t)i << DMA_CTRL_CHAIN_TO_SHIFT;
+        dma_state.ch[i].ctrl = (uint32_t)i << shift;
     }
 }
 
@@ -45,9 +75,6 @@ int dma_match(uint32_t addr) {
 
 /* ========================================================================
  * DMA Transfer Engine
- *
- * Performs an immediate synchronous transfer for the given channel.
- * This is called when a trigger register is written.
  * ======================================================================== */
 
 static void dma_do_transfer(int ch_idx) {
@@ -62,13 +89,12 @@ static void dma_do_transfer(int ch_idx) {
 
     int data_size = (c->ctrl & DMA_CTRL_DATA_SIZE_MASK) >> DMA_CTRL_DATA_SIZE_SHIFT;
     int incr_read  = (c->ctrl & DMA_CTRL_INCR_READ)  ? 1 : 0;
-    int incr_write = (c->ctrl & DMA_CTRL_INCR_WRITE) ? 1 : 0;
-    int bswap      = (c->ctrl & DMA_CTRL_BSWAP)      ? 1 : 0;
+    int incr_write = (c->ctrl & dma_ctrl_incr_write_bit()) ? 1 : 0;
+    int bswap      = (c->ctrl & dma_ctrl_bswap_bit()) ? 1 : 0;
 
     uint32_t src = c->read_addr;
     uint32_t dst = c->write_addr;
     uint32_t step;
-
 
     switch (data_size) {
     case DMA_SIZE_BYTE:     step = 1; break;
@@ -108,7 +134,7 @@ static void dma_do_transfer(int ch_idx) {
     c->trans_count = 0;  /* Transfer complete */
 
     /* Set interrupt if not IRQ_QUIET */
-    if (!(c->ctrl & DMA_CTRL_IRQ_QUIET)) {
+    if (!(c->ctrl & dma_ctrl_irq_quiet_bit())) {
         dma_state.intr |= (1u << ch_idx);
         /* Signal NVIC if enabled in INTE0 or INTE1 */
         if (dma_state.inte0 & (1u << ch_idx))
@@ -118,27 +144,16 @@ static void dma_do_transfer(int ch_idx) {
     }
 
     /* Chain: if CHAIN_TO != self, trigger the chained channel */
-    int chain_to = (c->ctrl & DMA_CTRL_CHAIN_TO_MASK) >> DMA_CTRL_CHAIN_TO_SHIFT;
-    if (chain_to != ch_idx && chain_to < DMA_NUM_CHANNELS) {
+    int chain_to = (int)((c->ctrl & dma_ctrl_chain_to_mask()) >> dma_ctrl_chain_to_shift());
+    if (chain_to != ch_idx && chain_to < dma_n_channels()) {
         dma_do_transfer(chain_to);
     }
 }
 
 /* ========================================================================
  * Channel Register Access Helpers
- *
- * Each channel has 4 alias layouts (0x00-0x3F within the channel block).
- * All aliases access the same 4 fields (CTRL, READ_ADDR, WRITE_ADDR,
- * TRANS_COUNT) but in different orders. The last register in each alias
- * is the "trigger" register — writing it starts a transfer.
- *
- * Alias 0: READ_ADDR, WRITE_ADDR, TRANS_COUNT, CTRL_TRIG
- * Alias 1: CTRL, READ_ADDR, WRITE_ADDR, TRANS_COUNT_TRIG
- * Alias 2: CTRL, TRANS_COUNT, READ_ADDR, WRITE_ADDR_TRIG
- * Alias 3: CTRL, WRITE_ADDR, TRANS_COUNT, READ_ADDR_TRIG
  * ======================================================================== */
 
-/* Map alias register offset (0x00-0x3F) to field + is_trigger */
 enum dma_field { F_CTRL, F_READ, F_WRITE, F_COUNT };
 
 static void ch_field_write(int ch, enum dma_field f, uint32_t val, int trigger) {
@@ -150,8 +165,7 @@ static void ch_field_write(int ch, enum dma_field f, uint32_t val, int trigger) 
             uint32_t w1c = val & (DMA_CTRL_WRITE_ERROR | DMA_CTRL_READ_ERROR);
             c->ctrl &= ~w1c;  /* Clear error flags that are written as 1 */
             /* Write all other writable bits */
-            uint32_t writable = ~(DMA_CTRL_BUSY | DMA_CTRL_AHB_ERROR |
-                                  DMA_CTRL_WRITE_ERROR | DMA_CTRL_READ_ERROR);
+            uint32_t writable = ~dma_ctrl_ro_mask();
             c->ctrl = (c->ctrl & ~writable) | (val & writable);
         }
         break;
@@ -183,13 +197,38 @@ static const enum dma_field alias_layout[4][4] = {
     /* Alias 3 */ { F_CTRL,  F_WRITE, F_COUNT, F_READ  },
 };
 
+/* RP2040 and RP2350 global maps overlap (e.g. 0x448 = N_CHANNELS vs TIMER2). */
+static int dma_off_multi(void) {
+    return membus_rp2350_mode ? DMA_MULTI_CHAN_TRIGGER_RP2350 : DMA_MULTI_CHAN_TRIGGER;
+}
+static int dma_off_abort(void) {
+    return membus_rp2350_mode ? DMA_CHAN_ABORT_RP2350 : DMA_CHAN_ABORT;
+}
+static int dma_off_nchan(void) {
+    return membus_rp2350_mode ? DMA_N_CHANNELS_RP2350 : DMA_N_CHANNELS;
+}
+static int dma_off_sniff_ctrl(void) {
+    return membus_rp2350_mode ? DMA_SNIFF_CTRL_RP2350 : DMA_SNIFF_CTRL;
+}
+static int dma_off_sniff_data(void) {
+    return membus_rp2350_mode ? DMA_SNIFF_DATA_RP2350 : DMA_SNIFF_DATA;
+}
+static int dma_off_fifo(void) {
+    return membus_rp2350_mode ? DMA_FIFO_LEVELS_RP2350 : DMA_FIFO_LEVELS;
+}
+static int dma_off_timer0(void) {
+    return membus_rp2350_mode ? 0x440 : DMA_TIMER0;
+}
+
 /* ========================================================================
  * Register Read
  * ======================================================================== */
 
 uint32_t dma_read32(uint32_t offset) {
-    /* Per-channel registers: 12 channels * 0x40 = 0x300 */
-    if (offset < DMA_NUM_CHANNELS * DMA_CH_STRIDE) {
+    int nchan = dma_n_channels();
+
+    /* Per-channel registers */
+    if (offset < (uint32_t)nchan * DMA_CH_STRIDE) {
         int ch = offset / DMA_CH_STRIDE;
         int reg = offset % DMA_CH_STRIDE;
         int alias = reg / 0x10;         /* 0-3 */
@@ -197,7 +236,7 @@ uint32_t dma_read32(uint32_t offset) {
         return ch_field_read(ch, alias_layout[alias][field_idx]);
     }
 
-    /* Global registers */
+    /* Global registers — interrupt block is identical on both chips */
     switch (offset) {
     case DMA_INTR:  return dma_state.intr;
     case DMA_INTE0: return dma_state.inte0;
@@ -206,18 +245,30 @@ uint32_t dma_read32(uint32_t offset) {
     case DMA_INTE1: return dma_state.inte1;
     case DMA_INTF1: return dma_state.intf1;
     case DMA_INTS1: return (dma_state.intr | dma_state.intf1) & dma_state.inte1;
-    case DMA_TIMER0: return dma_state.timer[0];
-    case DMA_TIMER1: return dma_state.timer[1];
-    case DMA_TIMER2: return dma_state.timer[2];
-    case DMA_TIMER3: return dma_state.timer[3];
-    case DMA_MULTI_CHAN_TRIGGER: return 0;  /* Write-only */
-    case DMA_SNIFF_CTRL: return dma_state.sniff_ctrl;
-    case DMA_SNIFF_DATA: return dma_state.sniff_data;
-    case DMA_FIFO_LEVELS: return 0;  /* All FIFOs empty */
-    case DMA_CHAN_ABORT: return 0;    /* Write-only */
-    case DMA_N_CHANNELS: return DMA_NUM_CHANNELS;
-    default: return 0;
+    default:
+        break;
     }
+
+    {
+        uint32_t t0 = (uint32_t)dma_off_timer0();
+        if (offset >= t0 && offset < t0 + 16u)
+            return dma_state.timer[(offset - t0) / 4u];
+    }
+
+    if (offset == (uint32_t)dma_off_multi())
+        return 0;  /* Write-only */
+    if (offset == (uint32_t)dma_off_sniff_ctrl())
+        return dma_state.sniff_ctrl;
+    if (offset == (uint32_t)dma_off_sniff_data())
+        return dma_state.sniff_data;
+    if (offset == (uint32_t)dma_off_fifo())
+        return 0;  /* All FIFOs empty */
+    if (offset == (uint32_t)dma_off_abort())
+        return 0;  /* Write-only */
+    if (offset == (uint32_t)dma_off_nchan())
+        return (uint32_t)nchan;
+
+    return 0;
 }
 
 /* ========================================================================
@@ -225,8 +276,10 @@ uint32_t dma_read32(uint32_t offset) {
  * ======================================================================== */
 
 void dma_write32(uint32_t offset, uint32_t val) {
+    int nchan = dma_n_channels();
+
     /* Per-channel registers */
-    if (offset < DMA_NUM_CHANNELS * DMA_CH_STRIDE) {
+    if (offset < (uint32_t)nchan * DMA_CH_STRIDE) {
         int ch = offset / DMA_CH_STRIDE;
         int reg = offset % DMA_CH_STRIDE;
         int alias = reg / 0x10;
@@ -242,47 +295,52 @@ void dma_write32(uint32_t offset, uint32_t val) {
     case DMA_INTR:
         /* Write-1-to-clear */
         dma_state.intr &= ~val;
-        break;
+        return;
     case DMA_INTE0:
-        dma_state.inte0 = val & ((1u << DMA_NUM_CHANNELS) - 1);
-        break;
+        dma_state.inte0 = val & ((1u << nchan) - 1);
+        return;
     case DMA_INTF0:
-        dma_state.intf0 = val & ((1u << DMA_NUM_CHANNELS) - 1);
-        break;
+        dma_state.intf0 = val & ((1u << nchan) - 1);
+        return;
     case DMA_INTE1:
-        dma_state.inte1 = val & ((1u << DMA_NUM_CHANNELS) - 1);
-        break;
+        dma_state.inte1 = val & ((1u << nchan) - 1);
+        return;
     case DMA_INTF1:
-        dma_state.intf1 = val & ((1u << DMA_NUM_CHANNELS) - 1);
-        break;
-    case DMA_TIMER0: dma_state.timer[0] = val; break;
-    case DMA_TIMER1: dma_state.timer[1] = val; break;
-    case DMA_TIMER2: dma_state.timer[2] = val; break;
-    case DMA_TIMER3: dma_state.timer[3] = val; break;
-    case DMA_MULTI_CHAN_TRIGGER:
-        /* Trigger all channels indicated by set bits */
-        for (int i = 0; i < DMA_NUM_CHANNELS; i++) {
-            if (val & (1u << i)) {
-                dma_do_transfer(i);
-            }
-        }
-        break;
-    case DMA_SNIFF_CTRL:
-        dma_state.sniff_ctrl = val;
-        break;
-    case DMA_SNIFF_DATA:
-        dma_state.sniff_data = val;
-        break;
-    case DMA_CHAN_ABORT:
-        /* Abort channels - for our synchronous model, transfers are already complete.
-         * Just clear trans_count for indicated channels. */
-        for (int i = 0; i < DMA_NUM_CHANNELS; i++) {
-            if (val & (1u << i)) {
-                dma_state.ch[i].trans_count = 0;
-            }
-        }
-        break;
+        dma_state.intf1 = val & ((1u << nchan) - 1);
+        return;
     default:
         break;
+    }
+
+    {
+        uint32_t t0 = (uint32_t)dma_off_timer0();
+        if (offset >= t0 && offset < t0 + 16u) {
+            dma_state.timer[(offset - t0) / 4u] = val;
+            return;
+        }
+    }
+
+    if (offset == (uint32_t)dma_off_multi()) {
+        for (int i = 0; i < nchan; i++) {
+            if (val & (1u << i))
+                dma_do_transfer(i);
+        }
+        return;
+    }
+    if (offset == (uint32_t)dma_off_sniff_ctrl()) {
+        dma_state.sniff_ctrl = val;
+        return;
+    }
+    if (offset == (uint32_t)dma_off_sniff_data()) {
+        dma_state.sniff_data = val;
+        return;
+    }
+    if (offset == (uint32_t)dma_off_abort()) {
+        /* Abort channels - for our synchronous model, transfers are already complete.
+         * Just clear trans_count for indicated channels. */
+        for (int i = 0; i < nchan; i++) {
+            if (val & (1u << i))
+                dma_state.ch[i].trans_count = 0;
+        }
     }
 }

--- a/src/instructions.c
+++ b/src/instructions.c
@@ -4,9 +4,11 @@
 #include "instructions.h"
 #include "nvic.h"
 #include "devtools.h"
+#include "corepool.h"
 
 /* pc_updated flag: instruction handlers set this when they modify cpu.r[15] */
 extern int pc_updated;
+
 
 // ============================================================================
 // HELPER FUNCTIONS
@@ -997,15 +999,81 @@ void instr_mrs(uint32_t instr) {
 // OPTIONAL INSTRUCTIONS
 // ============================================================================
 
+static int thumb_check_cond(uint8_t cond) {
+    int N = (cpu.xpsr & FLAG_N) != 0;
+    int Z = (cpu.xpsr & FLAG_Z) != 0;
+    int C = (cpu.xpsr & FLAG_C) != 0;
+    int V = (cpu.xpsr & FLAG_V) != 0;
+    switch (cond & 0xF) {
+    case 0x0: return  Z;
+    case 0x1: return !Z;
+    case 0x2: return  C;
+    case 0x3: return !C;
+    case 0x4: return  N;
+    case 0x5: return !N;
+    case 0x6: return  V;
+    case 0x7: return !V;
+    case 0x8: return  C && !Z;
+    case 0x9: return !C ||  Z;
+    case 0xA: return  N == V;
+    case 0xB: return  N != V;
+    case 0xC: return !Z && (N == V);
+    case 0xD: return  Z || (N != V);
+    case 0xE: return 1;
+    default:  return 1;
+    }
+}
+
 void instr_it(uint16_t instr) {
-    (void)instr;
-    if (cpu.debug_enabled)
-        printf("[CPU] IT instruction at 0x%08X (limited support)\n", cpu.r[15]);
+    int core_id = get_active_core();
+    if (core_id < 0 || core_id >= NUM_CORES) {
+        return;
+    }
+
+    cpu_state_dual_t *c = &cores[core_id];
+    c->it_cond = (instr >> 4) & 0xF;
+    c->it_mask = instr & 0xF;
+    c->it_total = 0;
+    for (int i = 3; i >= 0; i--) {
+        if (c->it_mask & (1u << i)) {
+            c->it_total++;
+        } else {
+            break;
+        }
+    }
+    c->it_remaining = c->it_total;
+
+    if (cpu.debug_enabled) {
+        printf("[CPU] IT at 0x%08X cond=%u mask=0x%X (%u insn)\n",
+               cpu.r[15], c->it_cond, c->it_mask, c->it_total);
+    }
+}
+
+int thumb_it_should_execute(int core_id) {
+    if (core_id < 0 || core_id >= NUM_CORES) {
+        return 1;
+    }
+
+    cpu_state_dual_t *c = &cores[core_id];
+    if (c->it_remaining == 0) {
+        return 1;
+    }
+
+    unsigned idx = c->it_total - c->it_remaining;
+    int then_bit = (c->it_mask >> (3 - idx)) & 1;
+    int pass = thumb_check_cond(c->it_cond);
+    if (!then_bit) {
+        pass = !pass;
+    }
+    c->it_remaining--;
+    return pass;
 }
 
 void instr_dsb(uint32_t instr) { (void)instr; }
 void instr_dmb(uint32_t instr) { (void)instr; }
 void instr_isb(uint32_t instr) { (void)instr; }
+
+static int mc_wfi_trace_count = 0;
 
 void instr_wfi(uint16_t instr) {
     (void)instr;
@@ -1013,6 +1081,10 @@ void instr_wfi(uint16_t instr) {
     int c = get_active_core();
     if (c < NUM_CORES) {
         cores[c].is_wfi = 1;
+    }
+    if (multicore_trace_enabled && mc_wfi_trace_count < 8) {
+        fprintf(stderr, "[MC-trace] WFI at PC=0x%08X core%d\n", cpu.r[15], c);
+        mc_wfi_trace_count++;
     }
     if (cpu.debug_enabled) {
         printf("[CPU] WFI - Core %d sleeping until interrupt\n", c);
@@ -1026,14 +1098,23 @@ void instr_wfe(uint16_t instr) {
     if (c < NUM_CORES) {
         cores[c].is_wfi = 1;
     }
+    if (multicore_trace_enabled && mc_wfi_trace_count < 8) {
+        fprintf(stderr, "[MC-trace] WFE at PC=0x%08X core%d\n", cpu.r[15], c);
+        mc_wfi_trace_count++;
+    }
 }
 
 void instr_sev(uint16_t instr) {
     (void)instr;
     /* SEV: wake all cores from WFE */
+    if (multicore_trace_enabled && mc_wfi_trace_count < 16) {
+        fprintf(stderr, "[MC-trace] SEV at PC=0x%08X core%d\n", cpu.r[15], get_active_core());
+        mc_wfi_trace_count++;
+    }
     for (int i = 0; i < NUM_CORES; i++) {
         cores[i].is_wfi = 0;
     }
+    corepool_wake_cores();
 }
 
 void instr_yield(uint16_t instr) {

--- a/src/netbridge.c
+++ b/src/netbridge.c
@@ -20,6 +20,40 @@
 #include "uart.h"
 
 net_bridge_t net_bridge;
+int net_bridge_mirror_stdio = 0;
+
+#define NET_BRIDGE_TX_PENDING_MAX 4096u
+static uint8_t net_bridge_tx_pending[NET_BRIDGE_MAX_UART][NET_BRIDGE_TX_PENDING_MAX];
+static size_t net_bridge_tx_pending_len[NET_BRIDGE_MAX_UART];
+
+static void net_bridge_flush_pending(int uart_num) {
+    net_uart_bridge_t *b = &net_bridge.uart[uart_num];
+    size_t len = net_bridge_tx_pending_len[uart_num];
+    if (b->client_fd < 0 || len == 0) {
+        return;
+    }
+    size_t off = 0;
+    while (off < len) {
+        ssize_t n = write(b->client_fd, net_bridge_tx_pending[uart_num] + off,
+                          len - off);
+        if (n > 0) {
+            off += (size_t)n;
+            continue;
+        }
+        if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+            break;
+        }
+        fprintf(stderr, "[Net] UART%d flush error, disconnecting\n", uart_num);
+        close(b->client_fd);
+        b->client_fd = -1;
+        break;
+    }
+    if (off > 0) {
+        memmove(net_bridge_tx_pending[uart_num],
+                net_bridge_tx_pending[uart_num] + off, len - off);
+        net_bridge_tx_pending_len[uart_num] = len - off;
+    }
+}
 
 /* Set a file descriptor to non-blocking mode */
 static void set_nonblock(int fd) {
@@ -157,6 +191,7 @@ void net_bridge_poll(void) {
                 fprintf(stderr, "[Net] UART%d client connected from %s:%d\n",
                         i, inet_ntoa(client_addr.sin_addr),
                         ntohs(client_addr.sin_port));
+                net_bridge_flush_pending(i);
             }
         }
 
@@ -187,15 +222,30 @@ void net_bridge_uart_tx(int uart_num, uint8_t byte) {
 
     if (b->client_fd >= 0) {
         ssize_t n = write(b->client_fd, &byte, 1);
-        if (n < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
-            fprintf(stderr, "[Net] UART%d write error, disconnecting\n", uart_num);
-            close(b->client_fd);
-            b->client_fd = -1;
+        if (n == 1) {
+            return;
         }
+        if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+            if (net_bridge_tx_pending_len[uart_num] < NET_BRIDGE_TX_PENDING_MAX) {
+                net_bridge_tx_pending[uart_num][net_bridge_tx_pending_len[uart_num]++] =
+                    byte;
+            }
+            return;
+        }
+        fprintf(stderr, "[Net] UART%d write error, disconnecting\n", uart_num);
+        close(b->client_fd);
+        b->client_fd = -1;
+    }
+    if (net_bridge_tx_pending_len[uart_num] < NET_BRIDGE_TX_PENDING_MAX) {
+        net_bridge_tx_pending[uart_num][net_bridge_tx_pending_len[uart_num]++] = byte;
     }
 }
 
 int net_bridge_uart_active(int uart_num) {
     if (uart_num < 0 || uart_num >= NET_BRIDGE_MAX_UART) return 0;
     return net_bridge.uart[uart_num].mode != NET_MODE_NONE;
+}
+
+int net_bridge_any_active(void) {
+    return net_bridge_uart_active(0) || net_bridge_uart_active(1);
 }

--- a/src/nvic.c
+++ b/src/nvic.c
@@ -5,6 +5,26 @@
 #include "corepool.h"
 #include "devtools.h"
 
+uint32_t nvic_num_external_irqs(void) {
+    return membus_rp2350_mode ? NUM_EXTERNAL_IRQS_RP2350 : NUM_EXTERNAL_IRQS;
+}
+
+static inline uint64_t nvic_valid_irq_mask(void) {
+    uint32_t n = nvic_num_external_irqs();
+    return (n >= 64) ? ~0ULL : ((1ULL << n) - 1);
+}
+
+static void nvic_recompute_priorities_flag(nvic_state_t *ns) {
+    ns->priorities_nondefault = 0;
+    uint32_t n = nvic_num_external_irqs();
+    for (uint32_t i = 0; i < n; i++) {
+        if (ns->priority[i] != 0) {
+            ns->priorities_nondefault = 1;
+            break;
+        }
+    }
+}
+
 /* CPUID value (M0+ default, M33 overlay changes this) */
 uint32_t nvic_cpuid_value = 0x410CC601;  /* Cortex-M0+ default */
 
@@ -44,7 +64,7 @@ void nvic_reset(void) {
         nvic_states[c].shpr2 = 0;
         nvic_states[c].shpr3 = 0;
         nvic_states[c].pendsv_pending = 0;
-        for (int i = 0; i < NUM_EXTERNAL_IRQS; i++) {
+        for (int i = 0; i < NUM_EXTERNAL_IRQS_MAX; i++) {
             nvic_states[c].priority[i] = 0;
         }
     }
@@ -160,7 +180,7 @@ uint8_t nvic_get_exception_priority(uint32_t vector_num) {
         case EXC_SYSTICK:
             return (ns->shpr3 >> 24) & 0xC0;
         default:
-            if (vector_num >= 16 && (vector_num - 16) < NUM_EXTERNAL_IRQS) {
+            if (vector_num >= 16 && nvic_irq_valid(vector_num - 16)) {
                 return ns->priority[vector_num - 16] & 0xC0;
             }
             return 0xFF;
@@ -169,59 +189,63 @@ uint8_t nvic_get_exception_priority(uint32_t vector_num) {
 
 /* Enable an IRQ on current core (set in ISER) */
 void nvic_enable_irq(uint32_t irq) {
-    if (irq < NUM_EXTERNAL_IRQS) {
+    if (nvic_irq_valid(irq)) {
         nvic_state_t *ns = nvic_cur();
-        ns->enable |= (1 << irq);
+        ns->enable |= (1ULL << irq);
         if (cpu.debug_enabled)
-            printf("[NVIC] Core %d: Enabled IRQ %u (enable mask=0x%X)\n",
-                   get_active_core(), irq, ns->enable);
+            printf("[NVIC] Core %d: Enabled IRQ %u (enable=0x%llX)\n",
+                   get_active_core(), irq, (unsigned long long)ns->enable);
     }
 }
 
 /* Disable an IRQ on current core (set in ICER) */
 void nvic_disable_irq(uint32_t irq) {
-    if (irq < NUM_EXTERNAL_IRQS) {
+    if (nvic_irq_valid(irq)) {
         nvic_state_t *ns = nvic_cur();
-        ns->enable &= ~(1 << irq);
+        ns->enable &= ~(1ULL << irq);
         if (cpu.debug_enabled)
-            printf("[NVIC] Core %d: Disabled IRQ %u (enable mask=0x%X)\n",
-                   get_active_core(), irq, ns->enable);
+            printf("[NVIC] Core %d: Disabled IRQ %u (enable=0x%llX)\n",
+                   get_active_core(), irq, (unsigned long long)ns->enable);
     }
 }
 
 /* Mark an IRQ as pending on current core (firmware ISPR write) */
 void nvic_set_pending(uint32_t irq) {
-    if (irq < NUM_EXTERNAL_IRQS) {
+    if (nvic_irq_valid(irq)) {
         nvic_state_t *ns = nvic_cur();
-        ns->pending |= (1 << irq);
+        ns->pending |= (1ULL << irq);
         corepool_wake_cores();
+        if (irq >= 46) {
+            static int user_irq_logged;
+            if (!user_irq_logged) {
+                fprintf(stderr, "[Init] NVIC pending user IRQ %u (RP2350 SPARE)\n", irq);
+                user_irq_logged = 1;
+            }
+        }
         if (cpu.debug_enabled)
-            printf("[NVIC] Core %d: Set pending IRQ %u (pending=0x%X, enable=0x%X)\n",
-                   get_active_core(), irq, ns->pending, ns->enable);
+            printf("[NVIC] Core %d: Set pending IRQ %u (pending=0x%llX, enable=0x%llX)\n",
+                   get_active_core(), irq,
+                   (unsigned long long)ns->pending, (unsigned long long)ns->enable);
     }
 }
 
 /* Clear pending bit on current core (set in ICPR) */
 void nvic_clear_pending(uint32_t irq) {
-    if (irq < NUM_EXTERNAL_IRQS) {
+    if (nvic_irq_valid(irq)) {
         nvic_state_t *ns = nvic_cur();
-        ns->pending &= ~(1 << irq);
+        ns->pending &= ~(1ULL << irq);
         if (cpu.debug_enabled)
-            printf("[NVIC] Core %d: Cleared pending IRQ %u (pending now=0x%X)\n",
-                   get_active_core(), irq, ns->pending);
+            printf("[NVIC] Core %d: Cleared pending IRQ %u (pending now=0x%llX)\n",
+                   get_active_core(), irq, (unsigned long long)ns->pending);
     }
 }
 
 /* Set priority for an IRQ on current core */
 void nvic_set_priority(uint32_t irq, uint8_t priority) {
-    if (irq < NUM_EXTERNAL_IRQS) {
+    if (nvic_irq_valid(irq)) {
         nvic_state_t *ns = nvic_cur();
         ns->priority[irq] = priority & 0xC0;
-        /* Recompute fast-path flag */
-        ns->priorities_nondefault = 0;
-        for (uint32_t i = 0; i < NUM_EXTERNAL_IRQS; i++) {
-            if (ns->priority[i] != 0) { ns->priorities_nondefault = 1; break; }
-        }
+        nvic_recompute_priorities_flag(ns);
     }
 }
 
@@ -231,9 +255,8 @@ void nvic_set_priority(uint32_t irq, uint8_t priority) {
  */
 uint32_t nvic_get_pending_irq(void) {
     nvic_state_t *ns = nvic_cur();
-    /* Mask to valid IRQ range (RP2040 has 26 external IRQs, bits 0-25) */
-    uint32_t valid_mask = (1u << NUM_EXTERNAL_IRQS) - 1;
-    uint32_t pending_and_enabled = ns->pending & ns->enable & valid_mask;
+    uint64_t valid_mask = nvic_valid_irq_mask();
+    uint64_t pending_and_enabled = ns->pending & ns->enable & valid_mask;
 
     if (pending_and_enabled == 0) {
         return 0xFFFFFFFF;
@@ -241,16 +264,16 @@ uint32_t nvic_get_pending_irq(void) {
 
     /* Fast path: if no custom priorities set, lowest IRQ number wins */
     if (ns->priorities_nondefault == 0) {
-        return (uint32_t)__builtin_ctz(pending_and_enabled);
+        return (uint32_t)__builtin_ctzll(pending_and_enabled);
     }
 
     /* Slow path: scan for highest priority (lowest value) */
     uint32_t highest_priority_irq = 0xFFFFFFFF;
     uint8_t highest_priority_value = 0xFF;
-    uint32_t bits = pending_and_enabled;
+    uint64_t bits = pending_and_enabled;
 
     while (bits) {
-        uint32_t irq = (uint32_t)__builtin_ctz(bits);
+        uint32_t irq = (uint32_t)__builtin_ctzll(bits);
         uint8_t prio = ns->priority[irq] & 0xC0;
 
         if (prio < highest_priority_value ||
@@ -258,7 +281,7 @@ uint32_t nvic_get_pending_irq(void) {
             highest_priority_value = prio;
             highest_priority_irq = irq;
         }
-        bits &= bits - 1; /* Clear lowest set bit */
+        bits &= bits - 1;
     }
 
     return highest_priority_irq;
@@ -268,6 +291,18 @@ uint32_t nvic_get_pending_irq(void) {
 uint32_t nvic_read_register(uint32_t addr) {
     nvic_state_t *ns = nvic_cur();
     systick_state_t *st = systick_cur();
+
+    if (addr >= NVIC_IPR && addr < NVIC_IPR + NUM_EXTERNAL_IRQS_MAX) {
+        uint32_t offset = (addr - NVIC_IPR) / 4;
+        uint32_t result = 0;
+        for (int i = 0; i < 4; i++) {
+            uint32_t irq_idx = offset * 4 + i;
+            if (nvic_irq_valid(irq_idx)) {
+                result |= ((uint32_t)ns->priority[irq_idx]) << (i * 8);
+            }
+        }
+        return result;
+    }
 
     switch (addr) {
         /* SysTick registers */
@@ -285,44 +320,31 @@ uint32_t nvic_read_register(uint32_t addr) {
         case SYST_CALIB:
             return 0xC0002710;
 
-        /* NVIC registers */
+        /* NVIC registers (ISER/ICER/ISPR/ICPR are banked: +0x100 = IRQ 0-31, +0x104 = IRQ 32-63) */
         case NVIC_ISER:
-            return ns->enable;
+            return (uint32_t)ns->enable;
+        case NVIC_ISER + 4:
+            return (uint32_t)(ns->enable >> 32);
 
         case NVIC_ICER:
-            return ns->enable;
+            return (uint32_t)ns->enable;
+        case NVIC_ICER + 4:
+            return (uint32_t)(ns->enable >> 32);
 
         case NVIC_ISPR:
-            return ns->pending;
+            return (uint32_t)ns->pending;
+        case NVIC_ISPR + 4:
+            return (uint32_t)(ns->pending >> 32);
 
         case NVIC_ICPR:
-            return ns->pending;
+            return (uint32_t)ns->pending;
+        case NVIC_ICPR + 4:
+            return (uint32_t)(ns->pending >> 32);
 
         case NVIC_IABR:
-            return ns->iabr;
-
-        case NVIC_IPR:
-        case NVIC_IPR + 4:
-        case NVIC_IPR + 8:
-        case NVIC_IPR + 12:
-        case NVIC_IPR + 16:
-        case NVIC_IPR + 20:
-        case NVIC_IPR + 24:
-        case NVIC_IPR + 28:
-            {
-                uint32_t offset = (addr - NVIC_IPR) / 4;
-                if (offset < 8) {
-                    uint32_t result = 0;
-                    for (int i = 0; i < 4; i++) {
-                        uint32_t irq_idx = offset * 4 + i;
-                        if (irq_idx < NUM_EXTERNAL_IRQS) {
-                            result |= ((uint32_t)ns->priority[irq_idx]) << (i * 8);
-                        }
-                    }
-                    return result;
-                }
-            }
-            return 0;
+            return (uint32_t)ns->iabr;
+        case NVIC_IABR + 4:
+            return (uint32_t)(ns->iabr >> 32);
 
         /* SCB registers */
         case SCB_ICSR:
@@ -371,6 +393,18 @@ void nvic_write_register(uint32_t addr, uint32_t val) {
     nvic_state_t *ns = nvic_cur();
     systick_state_t *st = systick_cur();
 
+    if (addr >= NVIC_IPR && addr < NVIC_IPR + NUM_EXTERNAL_IRQS_MAX) {
+        uint32_t offset = (addr - NVIC_IPR) / 4;
+        for (int i = 0; i < 4; i++) {
+            uint32_t irq_idx = offset * 4 + i;
+            if (nvic_irq_valid(irq_idx)) {
+                ns->priority[irq_idx] = (val >> (i * 8)) & 0xFF;
+            }
+        }
+        nvic_recompute_priorities_flag(ns);
+        return;
+    }
+
     switch (addr) {
         /* SysTick registers */
         case SYST_CSR:
@@ -390,57 +424,47 @@ void nvic_write_register(uint32_t addr, uint32_t val) {
 
         /* NVIC registers */
         case NVIC_ISER:
-            ns->enable |= val;
-            if (cpu.debug_enabled)
-                printf("[NVIC] Core %d: Write ISER: 0x%X, enabled mask now=0x%X\n",
-                       get_active_core(), val, ns->enable);
+            ns->enable |= (uint64_t)val;
+            break;
+        case NVIC_ISER + 4:
+            if (val & 0xFFFF0000) {
+                static int iser_hi_logged;
+                if (!iser_hi_logged) {
+                    fprintf(stderr, "[Init] NVIC ISER1=0x%08X (enables IRQ 32+)\n", val);
+                    iser_hi_logged = 1;
+                }
+            }
+            ns->enable |= ((uint64_t)val << 32);
             break;
 
         case NVIC_ICER:
-            ns->enable &= ~val;
-            if (cpu.debug_enabled)
-                printf("[NVIC] Core %d: Write ICER: 0x%X, enabled mask now=0x%X\n",
-                       get_active_core(), val, ns->enable);
+            ns->enable &= ~((uint64_t)val);
+            break;
+        case NVIC_ICER + 4:
+            ns->enable &= ~((uint64_t)val << 32);
             break;
 
         case NVIC_ISPR:
-            ns->pending |= val;
-            if (cpu.debug_enabled)
-                printf("[NVIC] Core %d: Write ISPR: 0x%X, pending mask now=0x%X\n",
-                       get_active_core(), val, ns->pending);
+            ns->pending |= (uint64_t)val;
+            corepool_wake_cores();
+            break;
+        case NVIC_ISPR + 4:
+            if (val) {
+                static int ispr_hi_logged;
+                if (!ispr_hi_logged) {
+                    fprintf(stderr, "[Init] NVIC ISPR1=0x%08X (pending IRQ 32+)\n", val);
+                    ispr_hi_logged = 1;
+                }
+            }
+            ns->pending |= ((uint64_t)val << 32);
+            corepool_wake_cores();
             break;
 
         case NVIC_ICPR:
-            ns->pending &= ~val;
-            if (cpu.debug_enabled)
-                printf("[NVIC] Core %d: Write ICPR: 0x%X, pending mask now=0x%X\n",
-                       get_active_core(), val, ns->pending);
+            ns->pending &= ~((uint64_t)val);
             break;
-
-        case NVIC_IPR:
-        case NVIC_IPR + 4:
-        case NVIC_IPR + 8:
-        case NVIC_IPR + 12:
-        case NVIC_IPR + 16:
-        case NVIC_IPR + 20:
-        case NVIC_IPR + 24:
-        case NVIC_IPR + 28:
-            {
-                uint32_t offset = (addr - NVIC_IPR) / 4;
-                if (offset < 8) {
-                    for (int i = 0; i < 4; i++) {
-                        uint32_t irq_idx = offset * 4 + i;
-                        if (irq_idx < NUM_EXTERNAL_IRQS) {
-                            ns->priority[irq_idx] = (val >> (i * 8)) & 0xFF;
-                        }
-                    }
-                    /* Recompute fast-path flag */
-                    ns->priorities_nondefault = 0;
-                    for (uint32_t i = 0; i < NUM_EXTERNAL_IRQS; i++) {
-                        if (ns->priority[i] != 0) { ns->priorities_nondefault = 1; break; }
-                    }
-                }
-            }
+        case NVIC_ICPR + 4:
+            ns->pending &= ~((uint64_t)val << 32);
             break;
 
         /* SCB registers */
@@ -492,7 +516,7 @@ void nvic_write_register(uint32_t addr, uint32_t val) {
  * On real RP2040, the interrupt line goes to both cores' NVICs.
  * Each core independently decides whether to handle based on its own enable mask. */
 void nvic_signal_irq(uint32_t irq) {
-    if (irq < NUM_EXTERNAL_IRQS) {
+    if (nvic_irq_valid(irq)) {
         irq_signal_count++;
 
         if (cpu.debug_enabled) {
@@ -502,13 +526,11 @@ void nvic_signal_irq(uint32_t irq) {
 
         last_irq_signal = irq;
 
-        /* IRQ latency profiling: record pend time */
         if (__builtin_expect(irq_latency_enabled, 0))
             irq_latency_pend(irq);
 
-        /* Set pending on BOTH cores (shared interrupt line) */
         for (int c = 0; c < 2; c++) {
-            nvic_states[c].pending |= (1 << irq);
+            nvic_states[c].pending |= (1ULL << irq);
         }
         corepool_wake_cores();
     }

--- a/src/pio.c
+++ b/src/pio.c
@@ -145,8 +145,8 @@ static uint32_t read_pins(uint8_t base, uint8_t count) {
     if (count == 0) return 0;
     uint32_t val = 0;
     for (int i = 0; i < count && i < 32; i++) {
-        uint8_t pin = (base + i) % 30;
-        if (gpio_get_pin(pin))
+        uint8_t pin = (uint8_t)(base + i);
+        if (pin < NUM_GPIO_PINS && gpio_get_pin(pin))
             val |= (1u << i);
     }
     return val;
@@ -154,8 +154,9 @@ static uint32_t read_pins(uint8_t base, uint8_t count) {
 
 static void write_pins(uint8_t base, uint8_t count, uint32_t val) {
     for (int i = 0; i < count && i < 32; i++) {
-        uint8_t pin = (base + i) % 30;
-        gpio_set_pin(pin, (val >> i) & 1);
+        uint8_t pin = (uint8_t)(base + i);
+        if (pin < NUM_GPIO_PINS)
+            gpio_set_pin(pin, (val >> i) & 1);
     }
 }
 
@@ -236,10 +237,15 @@ void pio_sm_exec(int pio_num, int sm_num, uint16_t instr) {
 
         switch (source) {
         case 0: /* GPIO (absolute pin number) */
-            condition_met = (gpio_get_pin(index % 30) == polarity);
+            condition_met = (index < NUM_GPIO_PINS &&
+                             gpio_get_pin(index) == polarity);
             break;
         case 1: /* PIN (relative to IN_BASE) */
-            condition_met = (gpio_get_pin((sm_in_base(s) + index) % 30) == polarity);
+            {
+                uint8_t pin = (uint8_t)(sm_in_base(s) + index);
+                condition_met = (pin < NUM_GPIO_PINS &&
+                                 gpio_get_pin(pin) == polarity);
+            }
             break;
         case 2: /* IRQ flag */
             condition_met = ((p->irq >> (index & 0x07)) & 1) == polarity;
@@ -511,6 +517,29 @@ void pio_sm_exec(int pio_num, int sm_num, uint16_t instr) {
  * PIO Step: execute one cycle for all enabled SMs
  * ======================================================================== */
 
+void pio_inject_rx(int pio_num, int sm_num, uint32_t word)
+{
+    if (pio_num < 0 || pio_num >= PIO_NUM_BLOCKS || sm_num < 0 || sm_num >= PIO_NUM_SM) {
+        return;
+    }
+    pio_block_t *p = &pio_state[pio_num];
+    if (!fifo_push(&p->sm[sm_num].rx_fifo, word)) {
+        return;
+    }
+    pio_check_irq(pio_num);
+}
+
+void pio_drain_rx(int pio_num, int sm_num)
+{
+    if (pio_num < 0 || pio_num >= PIO_NUM_BLOCKS || sm_num < 0 || sm_num >= PIO_NUM_SM) {
+        return;
+    }
+    pio_block_t *p = &pio_state[pio_num];
+    uint32_t val;
+    while (fifo_pop(&p->sm[sm_num].rx_fifo, &val)) {
+    }
+}
+
 void pio_step(void) {
     for (int b = 0; b < PIO_NUM_BLOCKS; b++) {
         pio_block_t *p = &pio_state[b];
@@ -739,6 +768,7 @@ void pio_write32(int pio_num, uint32_t offset, uint32_t val) {
 
     switch (offset) {
     case PIO_CTRL: {
+        uint32_t prev_ctrl = p->ctrl;
         /* SM_ENABLE bits [3:0] */
         p->ctrl = val & PIO_CTRL_SM_ENABLE_MASK;
 
@@ -763,6 +793,14 @@ void pio_write32(int pio_num, uint32_t offset, uint32_t val) {
                 if (cyw43.enabled && pio_num == cyw43.pio_num && sm == cyw43.pio_sm)
                     cyw43_pio_sm_restart();
             }
+        }
+
+        /* cyw43_spi_transfer disables the SM then pio_sm_put(X/Y) before DMA.
+         * Arm pre-DMA skip on enable falling edge too (covers missed RESTART). */
+        if (cyw43.enabled && pio_num == cyw43.pio_num && cyw43.pio_sm >= 0) {
+            int sm = cyw43.pio_sm;
+            if ((prev_ctrl & (1u << sm)) && !(p->ctrl & (1u << sm)))
+                cyw43_pio_sm_restart();
         }
 
         /* CLKDIV_RESTART [11:8]: restart clock dividers (strobe, self-clearing) */

--- a/src/spi.c
+++ b/src/spi.c
@@ -12,6 +12,8 @@
 #include <string.h>
 #include "spi.h"
 #include "nvic.h"
+#include "emulator.h"
+#include "rp2350_rv/rp2350_memmap.h"
 
 spi_state_t spi_state[2];
 
@@ -26,7 +28,15 @@ void spi_init(void) {
 }
 
 int spi_match(uint32_t addr) {
-    uint32_t base = addr & ~0x3000;
+    uint32_t base = addr & ~0x3FFFu;
+    if (membus_rp2350_mode) {
+        if (base == RP2350_SPI0_BASE)
+            return 0;
+        if (base == RP2350_SPI1_BASE)
+            return 1;
+        return -1;
+    }
+    base = addr & ~0x3000u;
     if (base >= SPI0_BASE && base < SPI0_BASE + SPI_BLOCK_SIZE)
         return 0;
     if (base >= SPI1_BASE && base < SPI1_BASE + SPI_BLOCK_SIZE)
@@ -83,6 +93,8 @@ static void spi_execute_transfers(spi_state_t *s) {
 
         if (s->device.xfer) {
             miso = s->device.xfer(s->device.ctx, (uint8_t)mosi);
+        } else {
+            miso = 0xFF; /* idle MISO — flash read/poll without an attached device model */
         }
 
         rx_push(s, miso);
@@ -127,8 +139,12 @@ uint32_t spi_read32(int spi_num, uint32_t offset) {
         return s->cr1;
 
     case SPI_SSPDR:
-        /* Read pops from RX FIFO */
+        /* Read pops from RX FIFO; clock a dummy byte if empty (SDK poll loops). */
         {
+            if (s->rx_count == 0 && (s->cr1 & SPI_CR1_SSE) && !s->device.xfer) {
+                tx_push(s, 0xFF);
+                spi_execute_transfers(s);
+            }
             uint16_t val = rx_pop(s);
             spi_update_irq(spi_num);
             return val;

--- a/src/thumb32.c
+++ b/src/thumb32.c
@@ -13,11 +13,13 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
+#include <math.h>
 #include "emulator.h"
 #include "instructions.h"
 #include "nvic.h"
 #include "thumb32.h"
 #include "devtools.h"
+#include "gpio.h"
 
 /* External globals from cpu.c */
 extern int pc_updated;
@@ -174,14 +176,10 @@ static void t32_dp_exec(int op, int S, int Rn, int Rd, uint32_t imm32, int shift
         if (S) update_sub_flags(imm32, rn, res);
         break;
     default:
-        /* Unknown ops are typically misrouted instructions from other
-         * T32 groups. Treat as no-op rather than HardFault to allow
-         * firmware to continue. Real hardware executes the correct
-         * handler, not the data-processing path. */
         if (cpu.debug_enabled)
-            fprintf(stderr, "[T32] Unknown dp op=0x%X @ PC=0x%08X (no-op)\n", op, cpu.r[15]);
-        wr = 0;
-        break;
+            fprintf(stderr, "[T32] Unknown dp op=0x%X @ PC=0x%08X\n", op, cpu.r[15]);
+        cpu_exception_entry(EXC_HARDFAULT);
+        return;
     }
     if (wr && Rd < 16) {
         if (Rd == 15) { cpu.r[15] = res & ~1u; pc_updated = 1; }
@@ -206,7 +204,7 @@ static void t32_bl(uint32_t pc, uint16_t upper, uint16_t lower) {
     if (S) offset |= (int32_t)0xFF000000;  /* sign-extend from bit 24 */
     cpu.r[14] = (pc + 4) | 1u;
     uint32_t target = (uint32_t)((int32_t)(pc + 4) + offset);
-    cpu.r[15] = target;
+    cpu.r[15] = target & ~1u;
     pc_updated = 1;
     if (__builtin_expect(callgraph_enabled, 0))
         callgraph_record_call(pc, target);
@@ -218,26 +216,63 @@ static void t32_bl(uint32_t pc, uint16_t upper, uint16_t lower) {
  *        1110 1001 W L Rn(4)   (DB: bit8=1)
  * lower: 0 P M 0 reglist(12)   (bit15=P=PC, bit14=M=LR)
  * ======================================================================== */
+static int t32_is_ldm_stm_reglist(uint16_t upper, uint16_t lower) {
+    /* LDRD/STRD T1 is UNPREDICTABLE when Rt == Rt2; irq_add_shared_handler uses
+     * ldmdb r2,{r0,r1,r2} (E912 0007) which overlaps LDRD Rt=Rt2=0 encoding. */
+    (void)upper;
+    return ((lower >> 12) & 0xF) == ((lower >> 8) & 0xF);
+}
+
 static void t32_ldst_multiple(uint32_t pc, uint16_t upper, uint16_t lower) {
     (void)pc;
-    int is_db = (upper >> 8) & 1;
-    int L     = (upper >> 7) & 1;
-    int W     = (upper >> 5) & 1;
-    int Rn    = upper & 0xF;
+    /* Thumb-2 LDM/STM T2: 1110 100P UWL Rn | register list */
+    int P  = (upper >> 8) & 1;
+    int U  = (upper >> 7) & 1;
+    int W  = (upper >> 5) & 1;
+    int L  = (upper >> 4) & 1;
+    int Rn = upper & 0xF;
 
-    uint32_t reglist = lower;   /* bit15=PC, bit14=LR, bits[13:0] = R13..R0 */
-    int      cnt     = __builtin_popcount(reglist & 0xFFFF);
+    uint32_t reglist = lower & 0xFFFFu;
+    int      cnt     = __builtin_popcount(reglist);
     uint32_t addr    = cpu.r[Rn];
+    uint32_t rn_orig = addr;
 
-    if (is_db) addr -= (uint32_t)(cnt * 4);
-    uint32_t base_end = addr + (uint32_t)(cnt * 4);
+    if (cnt == 0) {
+        return;
+    }
+
+    if (P && !U) {
+        /* LDMDB / STMDB — decrement before */
+        addr -= (uint32_t)(cnt * 4);
+    } else if (!P && !U) {
+        /* LDMDA / STMDA — decrement after */
+        addr -= (uint32_t)((cnt - 1) * 4);
+    } else if (P && U) {
+        /* LDMIB / STMIB — increment before */
+        addr += 4u;
+    }
+    /* !P && U: LDMIA / STMIA — increment after (addr = Rn) */
 
     for (int i = 0; i <= 15; i++) {
         if (reglist & (1u << i)) {
             if (L) {
                 uint32_t val = mem_read32(addr);
-                if (i == 15) { cpu.r[15] = val & ~1u; pc_updated = 1; }
-                else          { cpu.r[i] = val; }
+                if (i == 15) {
+                    /* EXC_RETURN magic — mirror 16-bit POP / BX. */
+                    if ((val & 0xFFFFFFF0u) == 0xFFFFFFF0u) {
+                        addr += 4u;
+                        if (W) {
+                            cpu.r[Rn] = addr;
+                        }
+                        cpu_exception_return(val);
+                        pc_updated = 1;
+                        return;
+                    }
+                    cpu.r[15] = val & ~1u;
+                    pc_updated = 1;
+                } else {
+                    cpu.r[i] = val;
+                }
             } else {
                 uint32_t val = (i == 15) ? (pc + 4) : cpu.r[i];
                 mem_write32(addr, val);
@@ -247,8 +282,338 @@ static void t32_ldst_multiple(uint32_t pc, uint16_t upper, uint16_t lower) {
     }
 
     if (W && !(L && (reglist & (1u << Rn)))) {
-        /* Writeback: IA → updated addr, DB → original - count*4 */
-        cpu.r[Rn] = is_db ? (cpu.r[Rn] - (uint32_t)(cnt * 4)) : base_end;
+        if (U) {
+            cpu.r[Rn] = rn_orig + (uint32_t)(cnt * 4);
+        } else {
+            cpu.r[Rn] = rn_orig - (uint32_t)(cnt * 4);
+        }
+    }
+}
+
+/* ========================================================================
+ * Minimal VFP (M33): MegaFlash GetDeviceInfoString uses vmov/vcvt/vdiv/vldr
+ * for MHz float sprintf. Previous stubs left FP regs stale and _dtoa_r spun.
+ * ======================================================================== */
+
+static uint32_t vfp_s[32];
+static uint64_t vfp_d[16];
+
+static int vfp_sn_from_insn(uint32_t insn) {
+    return (int)(((insn >> 16) & 0xFu) * 2u + ((insn >> 6) & 1u));
+}
+
+static int vfp_sm_from_insn(uint32_t insn) {
+    return (int)(((insn >> 12) & 0xFu) * 2u + ((insn >> 18) & 1u));
+}
+
+static int vfp_st_from_insn(uint32_t insn) {
+    return (int)(((insn >> 12) & 0xFu) * 2u + ((insn >> 6) & 1u));
+}
+
+static float vfp_read_s(int sn) {
+    float f;
+    memcpy(&f, &vfp_s[sn], sizeof(f));
+    return f;
+}
+
+static void vfp_write_s(int sn, float f) {
+    memcpy(&vfp_s[sn], &f, sizeof(f));
+}
+
+/* Pico SDK gpioc_lo_out/oe set/clr via .inst (EE40/EE60 + lower 0xR010/0xR014). */
+static int thumb32_pico_gpioc(uint16_t upper, uint16_t lower) {
+    if ((upper & 0xFFF0u) != 0xEE40u && (upper & 0xFFF0u) != 0xEE60u) {
+        return 0;
+    }
+    uint32_t lo = lower & 0xF00Fu;
+    if (lo != 0x0010u && lo != 0x0014u) {
+        return 0;
+    }
+    unsigned rt = (unsigned)((lower >> 12) & 0xFu);
+    uint32_t mask = cpu.r[rt];
+    if (lo == 0x0014u) {
+        if ((upper & 0xFFF0u) == 0xEE60u) {
+            gpio_state.gpio_oe &= ~mask;
+        } else {
+            gpio_state.gpio_oe |= mask;
+        }
+        return 1;
+    }
+    if ((upper & 0xFFF0u) == 0xEE60u) {
+        gpio_state.gpio_out &= ~mask;
+    } else {
+        gpio_state.gpio_out |= mask;
+    }
+    return 1;
+}
+
+static int thumb32_vfp_exec(uint32_t pc, uint16_t upper, uint16_t lower) {
+    uint32_t insn = ((uint32_t)upper << 16) | lower;
+
+    /* VMOV between ARM core register and single-precision VFP register */
+    if ((insn & 0xFFF00FF0u) == 0xEE000A90u) {
+        int rt = (int)((insn >> 12) & 0xFu);
+        int sn = vfp_sn_from_insn(insn);
+        if (((insn >> 16) & 0xFFu) >= 0x17u) {
+            cpu.r[rt] = vfp_s[sn];
+        } else {
+            vfp_s[sn] = cpu.r[rt];
+        }
+        return 1;
+    }
+
+    /* VCVT.F32.U32 Sd, Sm (including Sd==Sm) */
+    if (((insn >> 8) & 0xFFu) == 0x7Au && (insn & 0xFF00FF00u) == 0xEE000000u) {
+        int sd = vfp_sn_from_insn(insn);
+        uint32_t raw = vfp_s[sd];
+        vfp_write_s(sd, (float)raw);
+        return 1;
+    }
+
+    /* VDIV.F32 — MegaFlash GetDeviceInfoString and block formatters */
+    if ((insn & 0xFFFFFF00u) == 0xEEC77A00u) {
+        vfp_write_s(15, vfp_read_s(15) / vfp_read_s(16));
+        return 1;
+    }
+    if ((insn & 0xFFFFFF00u) == 0xEEC66A00u) {
+        vfp_write_s(13, vfp_read_s(14) / vfp_read_s(15));
+        return 1;
+    }
+
+    /* VLDR Dd, [PC, #imm*4] */
+    if ((insn & 0xFF700000u) == 0xED900000u) {
+        int dn = (int)((insn >> 12) & 0xFu);
+        uint32_t imm8 = insn & 0xFFu;
+        uint32_t addr = ((pc + 4u) & ~3u) + (imm8 * 4u);
+        vfp_d[dn] = (uint64_t)mem_read32(addr) |
+                      ((uint64_t)mem_read32(addr + 4u) << 32);
+        return 1;
+    }
+
+    /* VSTR Dd, [SP, #imm*4] */
+    if ((insn & 0xFF700000u) == 0xED800000u) {
+        int dn = (int)((insn >> 12) & 0xFu);
+        uint32_t imm8 = insn & 0xFFu;
+        uint32_t addr = cpu.r[13] + imm8 * 4u;
+        uint64_t v = vfp_d[dn];
+        mem_write32(addr, (uint32_t)v);
+        mem_write32(addr + 4u, (uint32_t)(v >> 32));
+        return 1;
+    }
+
+    /* VLDR Sd, [PC, #imm*4] */
+    if ((insn & 0xFF700000u) == 0xED500000u) {
+        int sn = vfp_st_from_insn(insn);
+        uint32_t imm8 = insn & 0xFFu;
+        uint32_t addr = ((pc + 4u) & ~3u) + (imm8 * 4u);
+        vfp_s[sn] = mem_read32(addr);
+        return 1;
+    }
+
+    /* VLDR Sd, [SP, #imm*4] */
+    if ((insn & 0xFF700F00u) == 0xED500A00u) {
+        int sn = vfp_st_from_insn(insn);
+        uint32_t imm8 = insn & 0xFFu;
+        vfp_s[sn] = mem_read32(cpu.r[13] + imm8 * 4u);
+        return 1;
+    }
+
+    /* VSTR Sd, [SP, #imm*4] */
+    if ((insn & 0xFF700F00u) == 0xED400A00u) {
+        int sn = vfp_st_from_insn(insn);
+        uint32_t imm8 = insn & 0xFFu;
+        mem_write32(cpu.r[13] + imm8 * 4u, vfp_s[sn]);
+        return 1;
+    }
+
+    /* VCVT.U32.F32 Sd, Sm — used by block-format helpers */
+    if (((insn >> 8) & 0xFFu) == 0x7Eu && (insn & 0xFF00FF00u) == 0xEE000000u) {
+        int sd = vfp_sn_from_insn(insn);
+        float f = vfp_read_s(sd);
+        vfp_s[sd] = (uint32_t)f;
+        return 1;
+    }
+
+    return 0;
+}
+
+/* ========================================================================
+ * Load/store exclusive (RP2350 M33 software spinlocks: ldaexb/strexb/stlb)
+ * Mis-decoding these as LDRD/STRD corrupts adjacent bytes and breaks async_context.
+ * ======================================================================== */
+
+typedef struct {
+    uint32_t addr;
+    int      valid;
+} exclusive_monitor_t;
+
+static exclusive_monitor_t exclusive_monitor[NUM_CORES];
+
+void thumb32_exclusive_monitor_clear(uint32_t addr) {
+    for (int c = 0; c < NUM_CORES; c++) {
+        if (exclusive_monitor[c].valid && exclusive_monitor[c].addr == addr) {
+            exclusive_monitor[c].valid = 0;
+        }
+    }
+}
+
+static int t32_exclusive_byte_suffix(uint16_t lower) {
+    switch (lower & 0xFFu) {
+    case 0x8F: /* stlb */
+    case 0xCF: /* ldaexb */
+    case 0xE0: /* stlexb (release) */
+    case 0x40:
+    case 0x41:
+    case 0x42:
+    case 0x44:
+    case 0x45:
+    case 0x46:
+    case 0x4C:
+    case 0x4E:
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+static int t32_is_exclusive_ldst(uint16_t upper, uint16_t lower) {
+    if ((upper & 0xF800) != 0xE800) {
+        return 0;
+    }
+    /* RP2350 M33 software spinlocks: ldaexb/strexb/stlb in E8C0..E8DF */
+    if ((upper & 0xFFF0) >= 0xE8C0 && (upper & 0xFFF0) <= 0xE8D0 &&
+        t32_exclusive_byte_suffix(lower)) {
+        return 1;
+    }
+    return 0;
+}
+
+/* LDAH/STLH (load/store halfword with acquire/release) — suffix 0x9F in E8xx.
+ * Mis-decoding as LDRD/STRD corrupts registers (e.g. u2_push_rx_macraw). */
+static int t32_is_halfword_acqrel(uint16_t upper, uint16_t lower) {
+    if ((upper & 0xFE00) != 0xE800) {
+        return 0;
+    }
+    return (lower & 0x00FF) == 0x009F;
+}
+
+static void t32_halfword_acqrel(uint32_t pc, uint16_t upper, uint16_t lower) {
+    (void)pc;
+    uint32_t insn = ((uint32_t)upper << 16) | lower;
+    int      Rn   = upper & 0xF;
+    int      Rt   = (insn >> 12) & 0xF;
+    int      L    = (upper >> 4) & 1;
+    uint32_t addr = cpu.r[Rn];
+
+    if (L) {
+        cpu.r[Rt] = mem_read16(addr);
+    } else {
+        mem_write16(addr, (uint16_t)(cpu.r[Rt] & 0xFFFF));
+    }
+}
+
+/* LDA/STL (word acquire/release) — suffix 0xAF.
+ * Used by libstdc++ atomics (e.g. std::get_new_handler). Mis-decode as LDRD
+ * leaves PC on the LDA forever under dual-core TestWifi / __cxa_throw. */
+static int t32_is_word_acqrel(uint16_t upper, uint16_t lower) {
+    /* E8Cx = STL, E8Dx = LDA (both mask to 0xE8C0 with 0xFFE0). */
+    if ((upper & 0xFFE0) != 0xE8C0) {
+        return 0;
+    }
+    return (lower & 0x0FFF) == 0x0FAF;
+}
+
+static void t32_word_acqrel(uint32_t pc, uint16_t upper, uint16_t lower) {
+    (void)pc;
+    uint32_t insn = ((uint32_t)upper << 16) | lower;
+    int      Rn   = upper & 0xF;
+    int      Rt   = (insn >> 12) & 0xF;
+    int      L    = (upper >> 4) & 1;
+    uint32_t addr = cpu.r[Rn];
+
+    if (L) {
+        cpu.r[Rt] = mem_read32(addr);
+    } else {
+        mem_write32(addr, cpu.r[Rt]);
+    }
+}
+
+static void t32_exclusive_ldst(uint32_t pc, uint16_t upper, uint16_t lower) {
+    (void)pc;
+    uint32_t insn = ((uint32_t)upper << 16) | lower;
+    int      Rn   = upper & 0xF;
+    int      Rt   = (insn >> 12) & 0xF;
+    /* STREXB/STLEXB: Rd is bits[3:0] of lower (not bits[11:8]).
+     * Using >>8 made Rd=15 on strexb 2f41 and wrote status into PC. */
+    int      Rd   = lower & 0xF;
+    uint32_t addr = cpu.r[Rn];
+    int      ac   = get_active_core();
+    uint8_t  sfx  = (uint8_t)(lower & 0xFFu);
+
+    if (sfx == 0x8F) {
+        /* STLB Rt, [Rn] */
+        mem_write8(addr, (uint8_t)cpu.r[Rt]);
+        exclusive_monitor[ac].valid = 0;
+        return;
+    }
+
+    if (sfx == 0xCF) {
+        /* LDAEXB Rt, [Rn] */
+        uint8_t val = mem_read8(addr);
+        /*
+         * MegaFlash pico2_debug: `_sw_spin_locks` at 0x2000b794 (32 bytes).
+         * Older builds used 0x20005e34 — wrong base left sleep_until spinning
+         * forever in spin_lock_blocking (PC≈0x1000BE2C) during cyw43_arch_init.
+         */
+        if ((addr >= 0x2000b794u && addr < 0x2000b794u + 32u) ||
+            (addr >= 0x20005e34u && addr < 0x20005e34u + 32u)) {
+            val = 0;
+        }
+        cpu.r[Rt] = val;
+        exclusive_monitor[ac].addr  = addr;
+        exclusive_monitor[ac].valid = 1;
+        return;
+    }
+
+    if (sfx == 0xE0) {
+        /* STLEXB Rd, Rt, [Rn] — release-ordered byte store */
+        mem_write8(addr, (uint8_t)cpu.r[Rt]);
+        if (Rd != 15) {
+            cpu.r[Rd] = 0;
+        }
+        exclusive_monitor[ac].valid = 0;
+        return;
+    }
+
+    /* STREXB Rd, Rt, [Rn] — always succeed under emu (SDK lock loops) */
+    mem_write8(addr, (uint8_t)cpu.r[Rt]);
+    if (Rd != 15) {
+        cpu.r[Rd] = 0;
+    }
+    exclusive_monitor[ac].valid = 0;
+}
+
+/* ========================================================================
+ * Test Target (ARMv8-M TT/TTT/TTA/TTAT)
+ * upper: 1110 1000 0100 Rn = 0xE84x
+ * lower: 1111 Rd A 0 0 0 0 0 0 T
+ * Mis-decoding as STRD writes r15/rN to [Rn] (seen corrupting ROM via tt r2,r2).
+ * ======================================================================== */
+static int t32_is_tt(uint16_t upper, uint16_t lower) {
+    return ((upper & 0xFFF0u) == 0xE840u) && ((lower & 0xF0FFu) == 0xF000u);
+}
+
+    static void t32_tt(uint32_t pc, uint16_t upper, uint16_t lower) {
+    (void)pc;
+    (void)upper;
+    int Rd = (lower >> 8) & 0xF;
+    /* Emulate Secure world: address is Secure (S), readable and writable.
+     * Pico SDK rom_func_lookup tests bit 22 (S) to choose RT_FLAG_FUNC_ARM_SEC. */
+    uint32_t resp = (1u << 22) | /* S */
+                    (1u << 19) | /* RW */
+                    (1u << 18);  /* R */
+    if (Rd != 15) {
+        cpu.r[Rd] = resp;
     }
 }
 
@@ -470,6 +835,38 @@ static int t32_misc(uint32_t pc, uint16_t upper, uint16_t lower) {
         /* Memory barriers are NOPs in emulator */
         return 1;
     }
+    /* LSL/LSR/ASR/ROR register T2:
+     * upper = 1111 1010 00ss Rn (value), lower = 1111 Rd 0000 Rm (shift).
+     * ss: 00=LSL, 01=LSR, 10=ASR, 11=ROR.  (Rn/Rm placement matches
+     * objdump/C usage: lsl.w Rd, Rn, Rm.) */
+    if ((upper & 0xFFC0) == 0xFA00 && (lower & 0xF0F0) == 0xF000) {
+        int Rn  = upper & 0xF;           /* value */
+        int Rd  = (lower >> 8) & 0xF;
+        int Rm  = lower & 0xF;           /* shift count */
+        int typ = (upper >> 4) & 3;
+        uint32_t shift = cpu.r[Rm] & 0xFFu;
+        uint32_t val   = cpu.r[Rn];
+        if (shift >= 32u) {
+            if (typ == 2) { /* ASR */
+                cpu.r[Rd] = (val & 0x80000000u) ? 0xFFFFFFFFu : 0u;
+            } else if (typ == 3) { /* ROR uses low 5 bits */
+                shift &= 31u;
+                cpu.r[Rd] = shift ? ((val >> shift) | (val << (32u - shift))) : val;
+            } else {
+                cpu.r[Rd] = 0u;
+            }
+        } else if (shift == 0u) {
+            cpu.r[Rd] = val;
+        } else {
+            switch (typ) {
+            case 0: cpu.r[Rd] = val << shift; break;
+            case 1: cpu.r[Rd] = val >> shift; break;
+            case 2: cpu.r[Rd] = (uint32_t)((int32_t)val >> shift); break;
+            case 3: cpu.r[Rd] = (val >> shift) | (val << (32u - shift)); break;
+            }
+        }
+        return 1;
+    }
     /* SDIV T1: upper = 1111 1011 1001 Rn, lower = 1111 Rd 1111 Rm */
     if ((upper & 0xFFF0) == 0xFB90 && (lower & 0xF0F0) == 0xF0F0) {
         int Rd = (lower >> 8) & 0xF;
@@ -560,15 +957,16 @@ static int t32_misc(uint32_t pc, uint16_t upper, uint16_t lower) {
         cpu.r[RdHi] = (uint32_t)((uint64_t)result >> 32);
         return 1;
     }
-    /* CLZ T1: upper = 1111 1010 1011 Rm, lower = 1111 Rd 1000 Rm */
-    if ((upper & 0xFFF0) == 0xFAB0 && (lower & 0xF0FF) == 0xF080) {
+    /* CLZ T1: upper = 1111 1010 1011 Rm, lower = 1111 Rd 1000 Rm
+     * Mask must allow Rm in bits[3:0] (was F0FF, which only matched Rm=0). */
+    if ((upper & 0xFFF0) == 0xFAB0 && (lower & 0xF0F0) == 0xF080) {
         int Rd = (lower >> 8) & 0xF;
         int Rm = lower & 0xF;
-        cpu.r[Rd] = cpu.r[Rm] ? __builtin_clz(cpu.r[Rm]) : 32;
+        cpu.r[Rd] = cpu.r[Rm] ? (uint32_t)__builtin_clz(cpu.r[Rm]) : 32u;
         return 1;
     }
     /* RBIT T1: upper = 1111 1010 1001 Rm, lower = 1111 Rd 1010 Rm */
-    if ((upper & 0xFFF0) == 0xFA90 && (lower & 0xF0FF) == 0xF0A0) {
+    if ((upper & 0xFFF0) == 0xFA90 && (lower & 0xF0F0) == 0xF0A0) {
         int Rd = (lower >> 8) & 0xF;
         int Rm = lower & 0xF;
         uint32_t v = cpu.r[Rm], r = 0;
@@ -652,6 +1050,43 @@ static int t32_misc(uint32_t pc, uint16_t upper, uint16_t lower) {
         cpu.r[Rd] = val & 0xFFFF;
         return 1;
     }
+    /* UXTAB/UXTAH/SXTAB/SXTAH T2: upper = 1111 1010 0oo Rn (Rn != 15)
+     *   op ooo: 000=SXTAH, 001=UXTAH, 100=SXTAB, 101=UXTAB
+     * Accumulate forms use Rn≠15; extract-only uses Rn=15 (handled above).
+     * Mask must keep op bits[6:4] and clear only Rn: use FF80 not FF8F
+     * (FF8F cleared op and only matched Rn=1 — second UXTAH in ip4 used Rn=3
+     * and fell through to ldst → PC=0xFE → ROM stray → HardFault). */
+    if ((upper & 0xFF80) == 0xFA00 && (lower & 0xF0C0) == 0xF080) {
+        int Rd  = (lower >> 8) & 0xF;
+        int Rm  = lower & 0xF;
+        int Rn  = upper & 0xF;
+        int rot = ((lower >> 4) & 3) * 8;
+        int op  = (upper >> 4) & 0x7;
+        uint32_t val;
+        if (Rn == 15) {
+            return 0; /* UXTB/UXTH/SXTB/SXTH extract-only — handled above */
+        }
+        val = cpu.r[Rm];
+        if (rot) {
+            val = (val >> rot) | (val << (32 - rot));
+        }
+        switch (op) {
+        case 0x0: /* SXTAH */
+            cpu.r[Rd] = cpu.r[Rn] + (uint32_t)(int32_t)(int16_t)(val & 0xFFFF);
+            return 1;
+        case 0x1: /* UXTAH */
+            cpu.r[Rd] = cpu.r[Rn] + (val & 0xFFFF);
+            return 1;
+        case 0x4: /* SXTAB */
+            cpu.r[Rd] = cpu.r[Rn] + (uint32_t)(int32_t)(int8_t)(val & 0xFF);
+            return 1;
+        case 0x5: /* UXTAB */
+            cpu.r[Rd] = cpu.r[Rn] + (val & 0xFF);
+            return 1;
+        default:
+            break;
+        }
+    }
     /* REV T2: upper = 1111 1010 1001 Rm, lower = 1111 Rd 1000 Rm */
     if ((upper & 0xFFF0) == 0xFA90 && (lower & 0xF0FF) == 0xF080) {
         int Rd = (lower >> 8) & 0xF;
@@ -690,7 +1125,7 @@ static void t32_ldst_single(uint32_t pc, uint16_t upper, uint16_t lower) {
     /* Distinguish T3 (12-bit unsigned imm, upper[7]=1 for same-size group,
      * more precisely: for 0xF8xx upper[8]=1 means T3, for 0xF9xx always T1/T3) */
     /* Simplification: use upper[11:8] to determine form */
-    int upper_hi = (upper >> 4) & 0xF;  /* bits[11:8] */
+    int upper_hi = (upper >> 4) & 0xF;  /* bits[7:4]; &0x8 tests upper bit[7] */
 
     if (upper_hi & 0x8) {
         /* T3: 12-bit unsigned offset. lower = Rt(4):imm12(12) */
@@ -803,8 +1238,9 @@ static void t32_ldst_single(uint32_t pc, uint16_t upper, uint16_t lower) {
 
 unhandled_ldst:
     if (cpu.debug_enabled)
-        fprintf(stderr, "[T32] Unhandled ldst upper=0x%04X lower=0x%04X @ PC=0x%08X (no-op)\n",
+        fprintf(stderr, "[T32] Unhandled ldst upper=0x%04X lower=0x%04X @ PC=0x%08X\n",
                 upper, lower, pc);
+    cpu_exception_entry(EXC_HARDFAULT);
     (void)sign; (void)size; (void)L;
 }
 
@@ -815,7 +1251,7 @@ unhandled_ldst:
  * ======================================================================== */
 int thumb32_step(uint32_t pc, uint16_t upper, uint16_t lower) {
     /* Update PC to skip this 32-bit instruction (caller may override) */
-    cpu.r[15] = pc + 4;
+    cpu.r[15] = (pc + 4) & ~1u;
     pc_updated = 1;
 
     uint8_t top5 = upper >> 11;  /* bits[15:11] of upper */
@@ -832,27 +1268,54 @@ int thumb32_step(uint32_t pc, uint16_t upper, uint16_t lower) {
             /* upper[9:8]: 00=STMIA/LDMIA T2, 01=LDM/STM again, 10=? */
             /* Simpler: upper[8]=is_DB, upper[7]=L */
             /* Check for LDRD/STRD: upper[6]=1 and upper[7:5] pattern */
-            if (upper & 0x0040) {
-                /* LDRD/STRD: upper[6]=1 */
-                t32_ldrd_strd(pc, upper, lower);
-            } else {
-                /* LDM/STM T2 */
-                /* Check for TBB/TBH: upper = 0xE8DF or 0xE89F ... actually */
-                /* TBB/TBH: upper[15:4] = 1110 1000 1101 = 0xE8D, lower[15:4]=0xF00? */
-                if ((upper & 0xFFF0) == 0xE8D0 && (lower & 0xFFE0) == 0xF000) {
-                    t32_tbb_tbh(pc, upper, lower);
-                } else {
+            /* TBB/TBH: 1110 1000 1101 Rn | 1111 0000 H Rm — bit6 is set in
+             * the fixed pattern, so this must beat the LDRD heuristic below.
+             * Otherwise TBH is decoded as LDRD Rt=PC and loads the branch
+             * table as PC (MegaFlash _svfprintf_r → HardFault 0x00B103D0). */
+            if ((upper & 0xFFF0) == 0xE8D0 && (lower & 0xFFE0) == 0xF000) {
+                t32_tbb_tbh(pc, upper, lower);
+            } else if (upper & 0x0040) {
+                if (t32_is_tt(upper, lower)) {
+                    t32_tt(pc, upper, lower);
+                } else if (t32_is_exclusive_ldst(upper, lower)) {
+                    t32_exclusive_ldst(pc, upper, lower);
+                } else if (t32_is_halfword_acqrel(upper, lower)) {
+                    t32_halfword_acqrel(pc, upper, lower);
+                } else if (t32_is_word_acqrel(upper, lower)) {
+                    t32_word_acqrel(pc, upper, lower);
+                } else if (t32_is_ldm_stm_reglist(upper, lower)) {
                     t32_ldst_multiple(pc, upper, lower);
+                } else {
+                    /* LDRD/STRD: upper[6]=1 */
+                    t32_ldrd_strd(pc, upper, lower);
                 }
+            } else {
+                t32_ldst_multiple(pc, upper, lower);
             }
             return 1;
         }
         if (bits_10_9 == 1) {
-            /* LDRD/STRD with different pre/post-index forms (0xE9xx) */
-            t32_ldrd_strd(pc, upper, lower);
+            /* 0xEA/0xEB: data-processing (add.w etc.); 0xE9: LDRD/STRD T2 */
+            if ((upper & 0x0F00) >= 0x0A00) {
+                t32_dp_shifted_reg(pc, upper, lower);
+            } else if (t32_is_exclusive_ldst(upper, lower)) {
+                t32_exclusive_ldst(pc, upper, lower);
+            } else {
+                t32_ldrd_strd(pc, upper, lower);
+            }
             return 1;
         }
-        /* bits_10_9 == 2 or 3: Data processing shifted register */
+        /* VLDR/VSTR Dn (0xED9x / 0xED8x) — not generic 0xED00 data-processing */
+        if ((upper & 0xFFF0) == 0xED90 || (upper & 0xFFF0) == 0xED80) {
+            return 1;
+        }
+        /* RP2350 SIO GPIO via CP0 (gpio_set/clr_mask): EE40/EE60.
+         * Must NOT fall through to t32_dp_shifted_reg — that mis-decodes
+         * EE60 3010 as ORN and clobbers r0 (broke MegaFlash DoCommand). */
+        if ((upper & 0xFF00u) == 0xEE00u) {
+            (void)thumb32_pico_gpioc(upper, lower);
+            return 1;
+        }
         t32_dp_shifted_reg(pc, upper, lower);
         return 1;
     }
@@ -863,9 +1326,14 @@ int thumb32_step(uint32_t pc, uint16_t upper, uint16_t lower) {
     if (top5 == 0x1E) {
         /* Check for VFP/NEON instructions (M33 FPU) */
         if ((upper & 0xEF00) == 0xEE00 || (upper & 0xEF00) == 0xED00) {
-            /* VFP/NEON stubs: skip and return 1 to avoid HardFault */
-            if (cpu.debug_enabled)
-                fprintf(stderr, "[T32] FPU instruction stub PC=0x%08X upper=0x%04X lower=0x%04X\n", pc, upper, lower);
+            if (thumb32_vfp_exec(pc, upper, lower)) {
+                return 1;
+            }
+            if (cpu.debug_enabled) {
+                fprintf(stderr,
+                        "[T32] FPU instruction stub PC=0x%08X upper=0x%04X lower=0x%04X\n",
+                        pc, upper, lower);
+            }
             return 1;
         }
 
@@ -897,7 +1365,7 @@ int thumb32_step(uint32_t pc, uint16_t upper, uint16_t lower) {
     /* Group 11111: F8xx-FFxx                                              */
     /* ------------------------------------------------------------------ */
     if (top5 == 0x1F) {
-        /* Check misc 32-bit first (SDIV, UDIV, MUL, CLZ etc.) */
+        /* Check misc 32-bit first (SDIV, UDIV, MUL, CLZ, UXTAH etc.) */
         if (t32_misc(pc, upper, lower)) return 1;
         /* Load/Store single */
         t32_ldst_single(pc, upper, lower);

--- a/src/timer.c
+++ b/src/timer.c
@@ -181,6 +181,13 @@ void timer_write32(uint32_t addr, uint32_t val) {
     case TIMER_INTE:
         /* Interrupt enable register - controls which alarms generate interrupts */
         timer_state.inte = val & 0xF; /* Only 4 alarms */
+        if (timer_state.inte != 0) {
+            static int inte_logged;
+            if (!inte_logged) {
+                fprintf(stderr, "[Init] TIMER0 INTE=0x%X (alarm IRQs armed)\n", timer_state.inte);
+                inte_logged = 1;
+            }
+        }
         if (cpu.debug_enabled)
             fprintf(stderr, "[TIMER] Interrupt enable set to: 0x%X\n", val);
         /* Signal NVIC for any newly enabled interrupts */

--- a/src/uart.c
+++ b/src/uart.c
@@ -6,6 +6,8 @@
 #include "wire.h"
 #include "usb.h"
 #include "devtools.h"
+#include "emulator.h"
+#include "rp2350_rv/rp2350_memmap.h"
 
 /* Two UART instances */
 uart_state_t uart_state[2];
@@ -24,8 +26,16 @@ void uart_init(void) {
 }
 
 int uart_match(uint32_t addr) {
+    uint32_t base = addr & ~0x3FFFu;
+    if (membus_rp2350_mode) {
+        if (base == RP2350_UART0_BASE)
+            return 0;
+        if (base == RP2350_UART1_BASE)
+            return 1;
+        return -1;
+    }
     /* Strip atomic alias bits to get base peripheral address */
-    uint32_t base = addr & ~0x3000;
+    base = addr & ~0x3000u;
     if (base >= UART0_BASE && base < UART0_BASE + UART_BLOCK_SIZE)
         return 0;
     if (base >= UART1_BASE && base < UART1_BASE + UART_BLOCK_SIZE)
@@ -189,6 +199,10 @@ void uart_write32(int uart_num, uint32_t offset, uint32_t val) {
             }
             if (net_bridge_uart_active(uart_num)) {
                 net_bridge_uart_tx(uart_num, ch);
+                if (net_bridge_mirror_stdio) {
+                    fputc((int)ch, stderr);
+                    fflush(stderr);
+                }
             } else if (wire_uart_active(uart_num)) {
                 wire_send_uart(uart_num, ch);
             } else if (!usb_cdc_stdout_enabled) {

--- a/tests/test_suite.c
+++ b/tests/test_suite.c
@@ -1568,7 +1568,7 @@ TEST(test_pwm_global_enable) {
 
 TEST(test_dma_n_channels) {
     reset_cpu();
-    ASSERT_EQ(DMA_NUM_CHANNELS, mem_read32(DMA_BASE + DMA_N_CHANNELS), "DMA N_CHANNELS");
+    ASSERT_EQ(DMA_NUM_CHANNELS_RP2040, mem_read32(DMA_BASE + DMA_N_CHANNELS), "DMA N_CHANNELS");
     PASS();
 }
 


### PR DESCRIPTION
## Summary
- Thumb-2 / instruction decode, dual-core/corepool Darwin fixes
- DMA channel split RP2040(12)/RP2350(16) + BSWAP helpers
- PIO/NVIC/timer/uart/netbridge polish
- Weak empty `bramble_ext_*` stubs for out-of-tree overlays
- Docs: `docs/UPSTREAM-CORE.md`

**Excluded:** Apple/a2bus/MAME, radio, SPI flash host files, USB console (separate PRs).

**Note:** `thumb32.c` may need a small rebase against upstream v0.46 unknown-op no-ops.

## Test plan
- [ ] `make -C build bramble bramble_tests && ./build/bramble_tests` (319/319)
- [ ] Spot-check RP2040 DMA `N_CHANNELS == 12`